### PR TITLE
Move typing keyboard origin to letter 'A'

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -173,7 +173,7 @@ typingKeyboad.addKeydownListener((event) => {
     baseMidiNote.value +
     scale.size * equaveShift.value +
     x * isomorphicHorizontal.value +
-    (4 - y) * isomorphicVertical.value;
+    (2 - y) * isomorphicVertical.value;
 
   return keyboardNoteOn(index);
 });


### PR DESCRIPTION
Pressing 'A' on the keyboard is the same as playing the base MIDI note

ref #138