### PR TITLE
Assign key colors on MOS scale creation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3941,11 +3941,11 @@
       "dev": true
     },
     "node_modules/moment-of-symmetry": {
-      "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/xenharmonic-devs/moment-of-symmetry.git#8a7235ff24c670cca95a881e41af28526cd3e625",
+      "version": "0.1.2",
+      "resolved": "git+ssh://git@github.com/xenharmonic-devs/moment-of-symmetry.git#02b72db8c76558157bc18dea5198c2eb4e8aab43",
       "license": "MIT",
       "dependencies": {
-        "fraction.js": "^4.2.0"
+        "xen-dev-utils": "github:xenharmonic-devs/xen-dev-utils"
       }
     },
     "node_modules/ms": {
@@ -8461,10 +8461,10 @@
       "dev": true
     },
     "moment-of-symmetry": {
-      "version": "git+ssh://git@github.com/xenharmonic-devs/moment-of-symmetry.git#8a7235ff24c670cca95a881e41af28526cd3e625",
+      "version": "git+ssh://git@github.com/xenharmonic-devs/moment-of-symmetry.git#02b72db8c76558157bc18dea5198c2eb4e8aab43",
       "from": "moment-of-symmetry@github:xenharmonic-devs/moment-of-symmetry",
       "requires": {
-        "fraction.js": "^4.2.0"
+        "xen-dev-utils": "github:xenharmonic-devs/xen-dev-utils"
       }
     },
     "ms": {

--- a/src/__tests__/scale.spec.ts
+++ b/src/__tests__/scale.spec.ts
@@ -4,6 +4,7 @@ import ExtendedMonzo from "../monzo";
 import Scale from "../scale";
 import { Interval, IntervalOptions } from "../interval";
 import { arraysEqual, Fraction } from "xen-dev-utils";
+import { mos } from "moment-of-symmetry";
 
 // TODO: Convert tests relevant for non-destructive editing #33
 describe("Scale", () => {
@@ -699,7 +700,8 @@ describe("Scale", () => {
   });
   it("can generate a MOS scale", () => {
     const octave = new Interval(ExtendedMonzo.fromNumber(2, 1), "ratio");
-    const bish = Scale.fromMos(3, 4, 2, 1, 3, octave);
+    const steps = mos(3, 4, 2, 1, 3);
+    const bish = Scale.fromEqualTemperamentSubset(steps, octave);
     expect(bish.getMonzo(0).toCents()).toBeCloseTo(0);
     expect(bish.getMonzo(1).toCents()).toBeCloseTo(120);
     expect(bish.getMonzo(2).toCents()).toBeCloseTo(360);
@@ -708,6 +710,21 @@ describe("Scale", () => {
     expect(bish.getMonzo(5).toCents()).toBeCloseTo(840);
     expect(bish.getMonzo(6).toCents()).toBeCloseTo(1080);
     expect(bish.getMonzo(7).toCents()).toBeCloseTo(1200);
+  });
+  it("formats MOS scales consistently", () => {
+    const octave = new Interval(ExtendedMonzo.fromNumber(2, 1), "ratio");
+    const steps = mos(5, 2, 2, 1, 5);
+    const major = Scale.fromEqualTemperamentSubset(steps, octave);
+    const expected = [
+      "2\\12",
+      "4\\12",
+      "5\\12",
+      "7\\12",
+      "9\\12",
+      "11\\12",
+      "12\\12",
+    ];
+    expect(arraysEqual(major.toStrings(), expected)).toBeTruthy();
   });
   /*
   it("can tile", () => {

--- a/src/components/ScaleBuilder.vue
+++ b/src/components/ScaleBuilder.vue
@@ -434,6 +434,7 @@ async function doImport(importerKey: ImporterKey, event: Event) {
         showMosModal = false;
         emit('update:scale', $event);
       "
+      @update:keyColors="emit('update:keyColors', $event)"
       @cancel="showMosModal = false"
     />
 

--- a/src/components/ScaleLineInput.vue
+++ b/src/components/ScaleLineInput.vue
@@ -22,6 +22,7 @@ watch(error, (newError) => element.value!.setCustomValidity(newError));
 <template>
   <input
     ref="element"
+    type="text"
     :value="modelValue"
     @input="$emit('update:modelValue', ($event.target as HTMLInputElement)!.value)"
   />

--- a/src/components/modals/generation/MosScale.vue
+++ b/src/components/modals/generation/MosScale.vue
@@ -256,7 +256,7 @@ function generate() {
               method = 'direct';
             "
           >
-            {{ info.pattern }}
+            {{ info.mosPattern }}
           </button>
           {{ info.hardness }}
           <i v-if="info.name !== undefined"
@@ -271,8 +271,8 @@ function generate() {
         <button @click="$emit('cancel')">Cancel</button>
         <template v-if="method === 'direct'">
           {{ ed }}<i>{{ tamnamsName }}</i
-          >{{ mosModeInfo.pattern }} {{ mosModeInfo.udp
-          }}<i v-if="mosModeInfo.mode">"{{ mosModeInfo.mode }}"</i
+          >{{ mosModeInfo.mode }} {{ mosModeInfo.udp
+          }}<i v-if="mosModeInfo.modeName">"{{ mosModeInfo.modeName }}"</i
           ><i>{{ hardness }}</i>
         </template>
         <i v-else>{{ previewName }}</i>

--- a/src/scale.ts
+++ b/src/scale.ts
@@ -1,5 +1,3 @@
-import { mos } from "moment-of-symmetry";
-
 import ExtendedMonzo from "@/monzo";
 import { Interval, type IntervalOptions } from "@/interval";
 import {
@@ -368,23 +366,18 @@ export default class Scale {
     );
   }
 
-  static fromMos(
-    numberOfLargeSteps: number,
-    numberOfSmallSteps: number,
-    sizeOfLargeStep: number,
-    sizeOfSmallStep: number,
-    brightGeneratorsUp: number,
+  static fromEqualTemperamentSubset(
+    steps: number[],
     equave: Interval,
     baseFrequency = 440
   ) {
-    const steps = mos(
-      numberOfLargeSteps,
-      numberOfSmallSteps,
-      sizeOfLargeStep,
-      sizeOfSmallStep,
-      brightGeneratorsUp
-    );
     const equaveSteps = steps[steps.length - 1];
+    equave = equave.mergeOptions({ preferredEtDenominator: equaveSteps });
+    if (equave.monzo.isFractional()) {
+      equave.options.preferredEtEquave = equave.monzo.toFraction();
+      equave.type = "equal temperament";
+    }
+
     return Scale.fromIntervalArray(
       steps.map((step) => equave.mul(new Fraction(step, equaveSteps))),
       baseFrequency


### PR DESCRIPTION
Update `moment-of-symmetry-dependecy`.
Add the option to assign parent MOS to white keys or to expand the scale to include new daughter MOS notes on black keys.