### PR TITLE
Configure MIDI velocity on/off and white only mode

### DIFF
--- a/src/midi.ts
+++ b/src/midi.ts
@@ -171,3 +171,31 @@ export class MidiIn {
     }
   }
 }
+
+export type MidiNoteInfo = {
+  whiteNumber?: number;
+  sharpOf?: number;
+  flatOf?: number;
+};
+
+const WHITES = [0, 2, 4, 5, 7, 9, 11];
+
+export function midiNoteInfo(chromaticNumber: number) {
+  const octave = Math.floor(chromaticNumber / 12);
+  const index = chromaticNumber - 12 * octave;
+  if (WHITES.includes(index)) {
+    return {
+      whiteNumber: Math.floor((index + 1) / 2) + 7 * octave,
+    };
+  }
+  if (index === 1 || index === 3) {
+    return {
+      sharpOf: (index - 1) / 2 + 7 * octave,
+      flatOf: (index + 1) / 2 + 7 * octave,
+    };
+  }
+  return {
+    sharpOf: index / 2 + 7 * octave,
+    flatOf: (index + 2) / 2 + 7 * octave,
+  };
+}

--- a/src/views/MidiView.vue
+++ b/src/views/MidiView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, reactive } from "vue";
+import { computed, onMounted, reactive } from "vue";
 import { Input, Output, WebMidi } from "webmidi";
 
 const props = defineProps<{
@@ -7,6 +7,9 @@ const props = defineProps<{
   midiOutput: Output | null;
   midiInputChannels: Set<number>;
   midiOutputChannels: Set<number>;
+  midiVelocityOn: boolean;
+  midiWhiteMode: boolean;
+  midiBlackAverage: boolean;
 }>();
 
 const emit = defineEmits([
@@ -14,10 +17,25 @@ const emit = defineEmits([
   "update:midiOutput",
   "update:midiInputChannels",
   "update:midiOutputChannels",
+  "update:midiVelocityOn",
+  "update:midiWhiteMode",
+  "update:midiBlackAverage",
 ]);
 
 const inputs = reactive<Input[]>([]);
 const outputs = reactive<Output[]>([]);
+const midiVelocityOn = computed({
+  get: () => props.midiVelocityOn,
+  set: (newValue) => emit("update:midiVelocityOn", newValue),
+});
+const midiWhiteMode = computed({
+  get: () => props.midiWhiteMode,
+  set: (newValue) => emit("update:midiWhiteMode", newValue),
+});
+const midiBlackAverage = computed({
+  get: () => props.midiBlackAverage,
+  set: (newValue) => emit("update:midiBlackAverage", newValue),
+});
 
 function selectMidiInput(event: Event) {
   const id = (event!.target as HTMLSelectElement).value;
@@ -115,6 +133,33 @@ onMounted(async () => {
                 @input="toggleInputChannel"
               />
             </span>
+          </div>
+          <div class="control checkbox-container">
+            <input
+              type="checkbox"
+              id="midi-velocity"
+              v-model="midiVelocityOn"
+            />
+            <label for="midi-velocity">Use velocity</label>
+          </div>
+          <div class="control checkbox-container">
+            <input
+              type="checkbox"
+              id="midi-white-mode"
+              v-model="midiWhiteMode"
+            />
+            <label for="midi-white-mode">Map white keys only</label>
+          </div>
+          <div class="control checkbox-container">
+            <input
+              type="checkbox"
+              id="midi-black-average"
+              :disabled="!midiWhiteMode"
+              v-model="midiBlackAverage"
+            />
+            <label for="midi-black-average"
+              >Play averaged notes on black keys</label
+            >
           </div>
           <label for="output">Output</label>
           <select id="output" @change="selectMidiOutput" class="control">


### PR DESCRIPTION
Add the option to average two white keys when playing a black key in white mode
Pass and distribute unmanipulated MIDI messages from IN to OUT.

refs #73 #172