### PR TITLE
Close modals when pressing Esc and autofocus when opened

### DIFF
--- a/src/components/ScaleBuilder.vue
+++ b/src/components/ScaleBuilder.vue
@@ -162,6 +162,7 @@ const showApproximateBySubharmonicsModal = ref(false);
 const showTemperModal = ref(false);
 const showEqualizeModal = ref(false);
 
+const scaleDataArea = ref<HTMLTextAreaElement | null>(null);
 const subsetModal = ref<any>(null);
 
 const scalaFile = ref<HTMLInputElement | null>(null);
@@ -224,7 +225,9 @@ async function doImport(importerKey: ImporterKey, event: Event) {
             <a href="#" @click="anamarkFile?.click()"><li>Import .tun</li></a>
             <a href="#"><li>Import .mnlgtuns / .mnltuno</li></a>
             <li class="divider"></li>
-            <a href="#" @click="joinedLines = ''"><li>Clear scale</li></a>
+            <a href="#" @click="joinedLines = ''; scaleDataArea!.focus()"
+              ><li>Clear scale</li></a
+            >
             <a href="#" @click="showPresetModal = true"
               ><li>Load preset scale</li></a
             >
@@ -233,13 +236,19 @@ async function doImport(importerKey: ImporterKey, event: Event) {
         <li class="btn-dropdown-group">
           <a class="btn" href="#">Modify scale ▼</a>
           <ul>
-            <a href="#" @click="$emit('update:scale', scale.sorted())"
+            <a
+              href="#"
+              @click="$emit('update:scale', scale.sorted()); scaleDataArea!.focus()"
               ><li>Sort ascending</li></a
             >
-            <a href="#" @click="$emit('update:scale', scale.reduce())"
+            <a
+              href="#"
+              @click="$emit('update:scale', scale.reduce()); scaleDataArea!.focus()"
               ><li>Reduce</li></a
             >
-            <a href="#" @click="$emit('update:scale', scale.invert())"
+            <a
+              href="#"
+              @click="$emit('update:scale', scale.invert()); scaleDataArea!.focus()"
               ><li>Invert</li></a
             >
             <a href="#" @click="showRotateModal = true"><li>Rotate</li></a>
@@ -273,7 +282,11 @@ async function doImport(importerKey: ImporterKey, event: Event) {
       <div class="control-group">
         <h2>Scale data</h2>
         <div class="control">
-          <textarea rows="12" v-model="joinedLines"></textarea>
+          <textarea
+            ref="scaleDataArea"
+            rows="12"
+            v-model="joinedLines"
+          ></textarea>
         </div>
       </div>
 


### PR DESCRIPTION
Focus on the first focusable element inside the modal body when opened.
Focus on scale data textarea after clicking on non-modals.
This closes the CSS dropdown.

ref #114