### PR TITLE
Fix cypress test

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ npm run build
 npm run test:e2e # or `npm run test:e2e:ci` for headless testing
 ```
 
+Please note that `cypress` expects the base URL to be `"/"`. Modify your local `vite.config.ts` accordingly before running e2e tests.
+
 ### Lint with [ESLint](https://eslint.org/)
 
 ```sh

--- a/cypress/integration/example.spec.ts
+++ b/cypress/integration/example.spec.ts
@@ -1,8 +1,8 @@
 // https://docs.cypress.io/api/introduction/api.html
 
-describe("My First Test", () => {
+describe("Basic test", () => {
   it("visits the app root url", () => {
     cy.visit("/");
-    cy.contains("h1", "You did it!");
+    cy.contains("h2", "Scale data");
   });
 });


### PR DESCRIPTION
Add notes about base URL needing to be / for e2e testing