### PR TITLE
Make tuning table highlight hacks support tabs

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -299,24 +299,33 @@ router.afterEach((to, from) => {
 // === Tuning table highlighting ===
 // We use hacks to bypass Vue state management for real-time gains
 function tuningTableKeyOn(index: number) {
-  if ("TUNING_TABLE_ROWS" in window && index >= 0 && index < 128) {
-    const tuningTableRow = (window as any).TUNING_TABLE_ROWS[index];
-    if (tuningTableRow?._rawValue) {
-      tuningTableRow._rawValue.classList.add("active");
-      tuningTableRow.heldKeys++;
+  if (index >= 0 && index < 128) {
+    let tuningTableRow = (window as any).TUNING_TABLE_ROWS[index];
+    if (tuningTableRow === undefined) {
+      tuningTableRow = { heldKeys: 0, element: null };
     }
+    tuningTableRow.heldKeys++;
+    if (tuningTableRow.element?._rawValue) {
+      tuningTableRow.element._rawValue.classList.add("active");
+    }
+    (window as any).TUNING_TABLE_ROWS[index] = tuningTableRow;
   }
   // Virtual keyboard state is too complex so we take the performance hit.
   heldNotes.set(index, (heldNotes.get(index) || 0) + 1);
 }
 
 function tuningTableKeyOff(index: number) {
-  if ("TUNING_TABLE_ROWS" in window && index >= 0 && index < 128) {
-    const tuningTableRow = (window as any).TUNING_TABLE_ROWS[index];
-    if (tuningTableRow?._rawValue) {
-      if (!--tuningTableRow.heldKeys) {
-        tuningTableRow._rawValue.classList.remove("active");
+  if (index >= 0 && index < 128) {
+    let tuningTableRow = (window as any).TUNING_TABLE_ROWS[index];
+    if (tuningTableRow === undefined) {
+      tuningTableRow = { heldKeys: 0, element: null };
+    }
+    tuningTableRow.heldKeys--;
+    if (tuningTableRow.element?._rawValue) {
+      if (!tuningTableRow.heldKeys) {
+        tuningTableRow.element._rawValue.classList.remove("active");
       }
+      (window as any).TUNING_TABLE_ROWS[index] = tuningTableRow;
     }
   }
   heldNotes.set(index, (heldNotes.get(index) || 1) - 1);

--- a/src/components/TuningTableRow.vue
+++ b/src/components/TuningTableRow.vue
@@ -18,14 +18,13 @@ const element = ref<HTMLTableRowElement | null>(null);
 // Application state is not suited for real-time display
 // se we use hacks to bypass it.
 onMounted(() => {
-  let rows;
-  if ("TUNING_TABLE_ROWS" in window) {
-    rows = (window as any).TUNING_TABLE_ROWS;
-  } else {
-    rows = (window as any).TUNING_TABLE_ROWS = Array(128);
+  const rows = (window as any).TUNING_TABLE_ROWS;
+  const heldKeys = rows[props.index]?.heldKeys || 0;
+  rows[props.index] = { heldKeys, element };
+
+  if (heldKeys) {
+    (element as any)._rawValue.classList.add("active");
   }
-  (element as any).heldKeys = 0;
-  rows[props.index] = element;
 
   const isMediumOrLarger = window.matchMedia(
     "screen and (min-width: 600px)"

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,9 @@ audioContext.suspend();
 // Custom waveforms need to be initialized only once.
 initializeCustomWaveforms(audioContext);
 
+// Hack to bypass Vue state management for real-time gains in table row highlighting.
+(window as any).TUNING_TABLE_ROWS = Array(128);
+
 const app = createApp(App, { audioContext });
 
 app.use(router);


### PR DESCRIPTION
Store hack state outside of hot reloading
Mount rows as active if keys pressed when switching to main tab

ref #329