### PR TITLE
VSCode extensions were renamed; update .vscode/extension.json …

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["johnsoncodehk.volar", "johnsoncodehk.vscode-typescript-vue-plugin"]
+  "recommendations": ["Vue.volar", "Vue.vscode-typescript-vue-plugin"]
 }


### PR DESCRIPTION
…accordingly. 

 I was also wondering if `vscode-typescript-vue-plugin` should be removed, since it's deprecated in favor of take-over mode, but the extension description page has a link to instructions for take-over mode, so I guess it's still useful.