### PR TITLE
Stop Firefox from bringing up Quick Find when '/' is pressed

### DIFF
--- a/src/keyboard.ts
+++ b/src/keyboard.ts
@@ -223,6 +223,7 @@ export class Keyboard {
     }
 
     if (COORDS_BY_CODE.has(event.code)) {
+      event.preventDefault(); // Stops Firefox from intercepting '/' for Quick Find
       this.activeKeys.add(event.code);
       if (event.shiftKey) {
         this.pendingKeys.add(event.code);


### PR DESCRIPTION
Fixes #407 

