### PR TITLE
Make the key index number viewable

### DIFF
--- a/src/components/VirtualKeyboard.vue
+++ b/src/components/VirtualKeyboard.vue
@@ -57,6 +57,7 @@ const isMousePressed = ref(false)
           'hidden-sm': key.x > 8,
           held: (heldNotes.get(key.index) || 0) > 0
         }"
+        :index="key.index"
         :color="key.color"
         :isMousePressed="isMousePressed"
         :noteOn="() => noteOn(key.index)"

--- a/src/components/VirtualKeyboardKey.vue
+++ b/src/components/VirtualKeyboardKey.vue
@@ -6,6 +6,7 @@ type NoteOff = () => void
 type NoteOnCallback = () => NoteOff
 
 const props = defineProps<{
+  index: number
   color: string
   isMousePressed: boolean
   noteOn: NoteOnCallback
@@ -97,6 +98,7 @@ onUnmounted(() => {
 
 <template>
   <td
+    :data-key-number="index"
     :style="'background-color:' + color"
     :class="{ active }"
     @touchstart="onTouchStart"


### PR DESCRIPTION
First time working with Vue here, so this is maybe not the best way to do this.

My problem is using the, virtual keyboard I'm confused which notes the keys are mapping to. I'm a new user of scale-workshop (just found it last weekend) and have been exploring different tonal system using the "load default" functionality.

Eventually (at least in my opinion) it would probably be helpful to have a setting that would overlay the key number and/of frequency over the keys to make it more clear for non-developers that wouldn't know how to find this info via DevTools.

For now I was just adding this because I find it useful at least. I can pop-open DevTools and double-check which key number for each key in the keyboard, and then cross reference that back to the build scale tab.