### PR TITLE
Swap the meaning of 'a' and 'A' in absolute and relative notation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scale-workshop",
-  "version": "3.0.0-beta.4",
+  "version": "3.0.0-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scale-workshop",
-      "version": "3.0.0-beta.4",
+      "version": "3.0.0-beta.5",
       "dependencies": {
         "isomorphic-qwerty": "^0.0.2",
         "ji-lattice": "^0.0.3",
@@ -14,7 +14,7 @@
         "moment-of-symmetry": "^0.4.2",
         "pinia": "^2.1.7",
         "qs": "^6.12.0",
-        "sonic-weave": "github:xenharmonic-devs/sonic-weave#v0.0.6",
+        "sonic-weave": "github:xenharmonic-devs/sonic-weave#v0.0.7",
         "sw-synth": "^0.1.0",
         "temperaments": "^0.5.3",
         "vue": "^3.3.4",
@@ -5060,8 +5060,8 @@
       }
     },
     "node_modules/sonic-weave": {
-      "version": "0.0.6",
-      "resolved": "git+ssh://git@github.com/xenharmonic-devs/sonic-weave.git#0913a00542f086be165638fe83754dbb5ace311b",
+      "version": "0.0.7",
+      "resolved": "git+ssh://git@github.com/xenharmonic-devs/sonic-weave.git#f13ad3ef56ce185d5cf4b44ecf68f0cff1cafaf7",
       "license": "MIT",
       "dependencies": {
         "moment-of-symmetry": "^0.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scale-workshop",
-  "version": "3.0.0-beta.4",
+  "version": "3.0.0-beta.5",
   "scripts": {
     "dev": "vite",
     "build": "run-p type-check \"build-only {@}\" --",
@@ -21,7 +21,7 @@
     "moment-of-symmetry": "^0.4.2",
     "pinia": "^2.1.7",
     "qs": "^6.12.0",
-    "sonic-weave": "github:xenharmonic-devs/sonic-weave#v0.0.6",
+    "sonic-weave": "github:xenharmonic-devs/sonic-weave#v0.0.7",
     "sw-synth": "^0.1.0",
     "temperaments": "^0.5.3",
     "vue": "^3.3.4",

--- a/src/character-palette.json
+++ b/src/character-palette.json
@@ -1,9 +1,10 @@
 {
-  "♮": "Natural sign. Signifies no change in pitch. Differentiates between augmented fourth <code>A4</code> and A natural four <code>A♮4</code>.",
+  "♮": "Natural sign. Signifies no change in pitch.",
   "♯": "Sharp sign. Raises pitch by <code>2187/2048</code>. E.g. F sharp four is spelled <code>F♯4</code>.",
   "♭": "Flat sign. Lowers pitch by <code>2187/2048</code>. E.g. B flat four is spelled <code>B♭4</code>.",
   "𝄪": "Double sharp sign. Raises pitch by <code>4782969/4194304</code>.",
   "𝄫": "Double flat sign. Lowers pitch by <code>4782969/4194304</code>.",
+  "Â": "Augmented interval quality. Capital A is reserved for absolute pitch so circumflexed <code>Â4</code> offers and alternative to <code>a4</code>.",
   "𝄲": "Quarter sharp sign. Raises pitch by <code>sqrt(2187/2048)</code>.",
   "‡": "Quarter sharp sign. Raises pitch by <code>sqrt(2187/2048)</code>.",
   "𝄳": "Quarter flat sign. Lowers pitch by <code>sqrt(2187/2048)</code>.",

--- a/src/components/modals/generation/EqualTemperament.vue
+++ b/src/components/modals/generation/EqualTemperament.vue
@@ -39,7 +39,7 @@ function generate(expand = true) {
       if (expand || !modal.simpleEd) {
         source = modal.degrees.map((steps) => `${steps}\\${edo}`).join('\n')
       } else {
-        source = `ed(${edo})`
+        source = `tet(${edo})`
       }
     } else {
       const ed = modal.divisions
@@ -47,7 +47,7 @@ function generate(expand = true) {
       if (expand || !modal.simpleEd) {
         source = modal.degrees.map((steps) => `${steps}\\${ed}<${ji}>`).join('\n')
       } else {
-        source = `ed(${ed}, ${ji})`
+        source = `tet(${ed}, ${ji})`
       }
     }
     emit('update:source', source)

--- a/src/exporters/__tests__/test-data.ts
+++ b/src/exporters/__tests__/test-data.ts
@@ -19,13 +19,14 @@ export function getTestData(appTitle: string) {
     subscripts: [[5, '']]
   })
   const visitor = getSourceVisitor()
-  visitor.visit(parseAST('a4 = 440 Hz').body[0])
+  visitor.visit(parseAST('A4 = 440 Hz').body[0])
   const ev = visitor.createExpressionVisitor()
   const relativeC5 = relative.bind(ev)(absoluteC5)
 
   const relativeIntervals = [
     new Interval(TimeMonzo.fromEqualTemperament('100/1200', 2, 3), 'logarithmic', {
       type: 'CentsLiteral',
+      sign: '',
       whole: 100n,
       fractional: ''
     }),
@@ -48,6 +49,7 @@ export function getTestData(appTitle: string) {
     }),
     new Interval(TimeMonzo.fromValue(Math.E / 2, 3), 'linear', {
       type: 'DecimalLiteral',
+      sign: '',
       whole: 1n,
       fractional: '3591409142295225',
       flavor: 'r',

--- a/src/presets.json
+++ b/src/presets.json
@@ -98,13 +98,13 @@
   "5edo": {
     "title": "Equal pentatonic",
     "name": "Equal pentatonic (5edo)",
-    "source": "ed(5)\nlabel([white, white, white, white, gray])\n",
+    "source": "tet(5)\nlabel([white, white, white, white, gray])\n",
     "categories": ["traditional", "equal temperament"]
   },
   "7edo": {
     "title": "Equal heptatonic",
     "name": "Equal heptatonic (7edo)",
-    "source": "ed(7)\ni => i white\npop() gray\n",
+    "source": "tet(7)\ni => i white\npop() gray\n",
     "categories": ["traditional", "equal temperament"]
   },
   "archytasdiatonic": {


### PR DESCRIPTION
Update sonic-weave dependency.
Adapt to core syntax changes in presets and code generators.

Associated sonic-weave changelog:
Add Â as an alternative for augmented.
Convert NEDJI projection to a binary operation with 'ed' Add more tiers of operator precedence.
Make rounding operators bind looser than harmonic segments. Make min and max bind looser than addition.
Rename stdlib 'ed' to 'tet' to avoid the now-reserved word. Swap u for w for step variety 8 to 13.
Implement a single command to organize() the scale.