### PR TITLE
Optimize CS check of octave-repeating JI GS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,13 +14,13 @@
         "moment-of-symmetry": "^0.4.2",
         "pinia": "^2.1.7",
         "qs": "^6.12.0",
-        "sonic-weave": "github:xenharmonic-devs/sonic-weave#v0.0.9",
+        "sonic-weave": "github:xenharmonic-devs/sonic-weave#v0.0.10",
         "sw-synth": "^0.1.0",
         "temperaments": "^0.5.3",
         "vue": "^3.3.4",
         "vue-router": "^4.3.0",
         "webmidi": "^3.1.8",
-        "xen-dev-utils": "^0.2.8",
+        "xen-dev-utils": "^0.2.9",
         "xen-midi": "^0.1.3"
       },
       "devDependencies": {
@@ -5414,12 +5414,12 @@
       }
     },
     "node_modules/sonic-weave": {
-      "version": "0.0.9",
-      "resolved": "git+ssh://git@github.com/xenharmonic-devs/sonic-weave.git#48d5cf0dd9026c978a8a0958957f73d036ef1001",
+      "version": "0.0.10",
+      "resolved": "git+ssh://git@github.com/xenharmonic-devs/sonic-weave.git#ae2d38a045cd9dc20a9bf443d690319c92a37278",
       "license": "MIT",
       "dependencies": {
         "moment-of-symmetry": "^0.4.2",
-        "xen-dev-utils": "^0.2.8"
+        "xen-dev-utils": "^0.2.9"
       },
       "bin": {
         "sonic-weave": "bin/sonic-weave.js"
@@ -6529,9 +6529,9 @@
       }
     },
     "node_modules/xen-dev-utils": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/xen-dev-utils/-/xen-dev-utils-0.2.8.tgz",
-      "integrity": "sha512-KvOrBQ2WgBIxQyfWaI/vzFpga9w/VN3NFYn4oF94Zf8/HVRSGV/PCB0v0/GasfQTzMPEh6rMJ38UB03CLZeYyA==",
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/xen-dev-utils/-/xen-dev-utils-0.2.9.tgz",
+      "integrity": "sha512-ngs85djTa5MH9yMomyFg1ZK1eETgtaG6FN5ZvDazyBbGmShuK/gOEWGRemHqm+I2zp3lOGbXlEU/M4SwYl3HLA==",
       "engines": {
         "node": ">=10.6.0"
       },

--- a/package.json
+++ b/package.json
@@ -21,13 +21,13 @@
     "moment-of-symmetry": "^0.4.2",
     "pinia": "^2.1.7",
     "qs": "^6.12.0",
-    "sonic-weave": "github:xenharmonic-devs/sonic-weave#v0.0.9",
+    "sonic-weave": "github:xenharmonic-devs/sonic-weave#v0.0.10",
     "sw-synth": "^0.1.0",
     "temperaments": "^0.5.3",
     "vue": "^3.3.4",
     "vue-router": "^4.3.0",
     "webmidi": "^3.1.8",
-    "xen-dev-utils": "^0.2.8",
+    "xen-dev-utils": "^0.2.9",
     "xen-midi": "^0.1.3"
   },
   "devDependencies": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 import { Interval, TimeMonzo } from 'sonic-weave'
 import { version } from '../package.json'
-import { Fraction } from 'xen-dev-utils'
+import { Fraction, PRIME_CENTS } from 'xen-dev-utils'
 
 // GLOBALS
 export const APP_TITLE = `Scale Workshop ${version}`
@@ -71,3 +71,9 @@ export const INTERVALS_12TET = [...Array(12).keys()].map(
       'logarithmic'
     )
 )
+
+export const CS_EDO = 5407372813
+export const CS_VAL = new TimeMonzo(new Fraction(0), [])
+for (let i = 0; i < DEFAULT_NUMBER_OF_COMPONENTS; ++i) {
+  CS_VAL.primeExponents.push(new Fraction(Math.round((PRIME_CENTS[i] / 1200.0) * CS_EDO)))
+}


### PR DESCRIPTION
Temper to 5407372813edo to produce potential counter-examples for JI GS CS.
Update xen-dev-utils and sonic-weave dependencies.