### PR TITLE
Remove dropdown for Pythagorean enharmonic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scale-workshop",
-  "version": "3.0.0-beta.9",
+  "version": "3.0.0-beta.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scale-workshop",
-      "version": "3.0.0-beta.9",
+      "version": "3.0.0-beta.10",
       "dependencies": {
         "isomorphic-qwerty": "^0.0.2",
         "ji-lattice": "^0.0.3",
@@ -14,7 +14,7 @@
         "moment-of-symmetry": "^0.4.2",
         "pinia": "^2.1.7",
         "qs": "^6.12.0",
-        "sonic-weave": "github:xenharmonic-devs/sonic-weave#v0.0.10",
+        "sonic-weave": "github:xenharmonic-devs/sonic-weave#v0.0.11",
         "sw-synth": "^0.1.0",
         "temperaments": "^0.5.3",
         "vue": "^3.3.4",
@@ -5414,8 +5414,8 @@
       }
     },
     "node_modules/sonic-weave": {
-      "version": "0.0.10",
-      "resolved": "git+ssh://git@github.com/xenharmonic-devs/sonic-weave.git#ae2d38a045cd9dc20a9bf443d690319c92a37278",
+      "version": "0.0.11",
+      "resolved": "git+ssh://git@github.com/xenharmonic-devs/sonic-weave.git#6e2e13671b926bc73998fe800862b8ce73b77892",
       "license": "MIT",
       "dependencies": {
         "moment-of-symmetry": "^0.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scale-workshop",
-  "version": "3.0.0-beta.9",
+  "version": "3.0.0-beta.10",
   "scripts": {
     "dev": "vite",
     "build": "run-p type-check \"build-only {@}\" --",
@@ -21,7 +21,7 @@
     "moment-of-symmetry": "^0.4.2",
     "pinia": "^2.1.7",
     "qs": "^6.12.0",
-    "sonic-weave": "github:xenharmonic-devs/sonic-weave#v0.0.10",
+    "sonic-weave": "github:xenharmonic-devs/sonic-weave#v0.0.11",
     "sw-synth": "^0.1.0",
     "temperaments": "^0.5.3",
     "vue": "^3.3.4",

--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -22,6 +22,7 @@
   --color-accent-dimmed: rgba(0, 20, 20, 0.7);
 
   --color-error: red;
+  --color-warning: orangered;
   --color-indicator: #c35;
 
   /* Mimic Bootstrap alert with 'danger' variant */
@@ -59,6 +60,7 @@
   --color-accent-dimmed: rgba(0, 20, 20, 0.7);
 
   --color-error: red;
+  --color-warning: orangered;
   --color-indicator: #b25;
 }
 

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -25,6 +25,9 @@ button {
 .error {
   color: var(--color-error);
 }
+.warning {
+  color: var(--color-warning);
+}
 code {
   display: inline-block;
   background-color: var(--color-background-soft);

--- a/src/components/ScaleControls.vue
+++ b/src/components/ScaleControls.vue
@@ -57,12 +57,6 @@ defineExpose({ focus, clearPaletteInfo })
         @input="updateScale"
       />
     </div>
-    <div class="control">
-      <label for="enharmonic">Pythagorean enharmonic</label>
-      <select id="enharmonic" v-model="scale.enharmonic" @input="updateScale">
-        <option v-for="e of scale.enharmonics" :key="e" :value="e">{{ e }}</option>
-      </select>
-    </div>
 
     <div class="control">
       <label for="base-frequency">Base frequency</label>
@@ -133,7 +127,8 @@ defineExpose({ focus, clearPaletteInfo })
       ></textarea>
     </div>
     <ScaleRule :scale="scale.scale" />
-    <p class="error">{{ scale.error }}</p>
+    <p v-if="scale.error" class="error">{{ scale.error }}</p>
+    <p v-else-if="scale.warning" class="warning">{{ scale.warning }}</p>
     <h3>Character palette</h3>
     <div class="control">
       <button

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -437,6 +437,25 @@ export function midiNoteNumberToEnharmonics(
   return result
 }
 
+const IS_BLACK_MIDI_NOTE = [
+  false, // C
+  true, // C# / Db
+  false, // D
+  true, // D# / Eb
+  false, // E
+  false, // F
+  true, // F# / Gb
+  false, // G
+  true, // G# / Ab
+  false, // A
+  true, // A# / Bb
+  false // B
+]
+
+export function isBlackMidiNote(noteNumber: number) {
+  return IS_BLACK_MIDI_NOTE[mmod(noteNumber, 12)]
+}
+
 export function annotateColors(sourceLines: string[], keyColors: string[]) {
   if (!keyColors.length) {
     return


### PR DESCRIPTION
Use the sharp enharmonic by default (MIDI standard). Motivate the user to declare an explicit root pitch when using a black base note.

ref #640