### PR TITLE
Include versions in the ambient context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scale-workshop",
-  "version": "3.0.0-beta.10",
+  "version": "3.0.0-beta.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scale-workshop",
-      "version": "3.0.0-beta.10",
+      "version": "3.0.0-beta.11",
       "dependencies": {
         "isomorphic-qwerty": "^0.0.2",
         "ji-lattice": "^0.0.3",
@@ -14,7 +14,7 @@
         "moment-of-symmetry": "^0.4.2",
         "pinia": "^2.1.7",
         "qs": "^6.12.0",
-        "sonic-weave": "github:xenharmonic-devs/sonic-weave#v0.0.11",
+        "sonic-weave": "github:xenharmonic-devs/sonic-weave#v0.0.12",
         "sw-synth": "^0.1.0",
         "temperaments": "^0.5.3",
         "vue": "^3.3.4",
@@ -5414,8 +5414,8 @@
       }
     },
     "node_modules/sonic-weave": {
-      "version": "0.0.11",
-      "resolved": "git+ssh://git@github.com/xenharmonic-devs/sonic-weave.git#6e2e13671b926bc73998fe800862b8ce73b77892",
+      "version": "0.0.12",
+      "resolved": "git+ssh://git@github.com/xenharmonic-devs/sonic-weave.git#771e2e17fd1336a867d90db08b9b2625c448b251",
       "license": "MIT",
       "dependencies": {
         "moment-of-symmetry": "^0.4.2",
@@ -5425,7 +5425,7 @@
         "sonic-weave": "bin/sonic-weave.js"
       },
       "engines": {
-        "node": ">=10.6.0"
+        "node": ">=12.0.0"
       },
       "funding": {
         "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scale-workshop",
-  "version": "3.0.0-beta.10",
+  "version": "3.0.0-beta.11",
   "scripts": {
     "dev": "vite",
     "build": "run-p type-check \"build-only {@}\" --",
@@ -21,7 +21,7 @@
     "moment-of-symmetry": "^0.4.2",
     "pinia": "^2.1.7",
     "qs": "^6.12.0",
-    "sonic-weave": "github:xenharmonic-devs/sonic-weave#v0.0.11",
+    "sonic-weave": "github:xenharmonic-devs/sonic-weave#v0.0.12",
     "sw-synth": "^0.1.0",
     "temperaments": "^0.5.3",
     "vue": "^3.3.4",

--- a/src/stores/scale.ts
+++ b/src/stores/scale.ts
@@ -25,6 +25,7 @@ import {
   repr
 } from 'sonic-weave'
 import {
+  APP_TITLE,
   DEFAULT_NUMBER_OF_COMPONENTS,
   INTERVALS_12TET,
   MIDI_NOTE_COLORS,
@@ -302,6 +303,7 @@ export const useScaleStore = defineStore('scale', () => {
     const _ = Interval.fromInteger(baseMidiNote.value)
     const baseFreq = new Interval(TimeMonzo.fromArbitraryFrequency(baseFrequency.value), 'linear')
     const extraBuiltins: Record<string, SonicWeaveValue> = {
+      APP_TITLE,
       scaleName: name.value,
       _,
       baseMidiNote: _,


### PR DESCRIPTION
Include APP_TITLE in the ambient context.

SonicWeave changelog:
* Include VERSION in the ambient context
* Only sort the record's part when pushing onto the scale
* Make conversions softer in terms of formatting if nothing needs to be changed
* Fix formatting of absolute intervals below C