### PR TITLE
Collaboration to issue #534

### DIFF
--- a/src/components/VirtualKeyInfo.vue
+++ b/src/components/VirtualKeyInfo.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import { formatHertz, formatExponential, formatCents } from '@/utils'
+
+const props = defineProps<{
+  label: string
+  cent: number
+  ratio: number
+  frequency: number
+  showLabel: boolean
+  showCent: boolean
+  showRatio: boolean
+  showFrequency: boolean
+}>()
+</script>
+
+<template>
+  <div class="key-info">
+    <div v-if="props.showLabel">
+      <strong>{{ props.label }}</strong>
+    </div>
+    <div v-if="props.showCent">{{ formatCents(props.cent, 0) }}</div>
+    <div v-if="props.showRatio">{{ formatExponential(props.ratio) }}</div>
+    <div v-if="props.showFrequency">{{ formatHertz(props.frequency) }}</div>
+  </div>
+</template>
+
+<style scoped>
+.key-info {
+  font-size: 1.25em;
+  text-shadow: 1px 1px 1px rgba(255, 255, 255, 0.3);
+}
+
+[data-theme='dark'] .key-info {
+  text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.3);
+}
+
+.black-key .key-info {
+  color: white;
+  text-shadow: none;
+}
+
+.white-key .key-info {
+  color: black;
+  text-shadow: none;
+}
+</style>

--- a/src/components/VirtualKeyboardKey.vue
+++ b/src/components/VirtualKeyboardKey.vue
@@ -100,7 +100,7 @@ onUnmounted(() => {
   <td
     :data-key-number="index"
     :style="'background-color:' + color"
-    :class="{ active }"
+    :class="{ active, 'black-key': color === 'black', 'white-key': color === 'white' }"
     @touchstart="onTouchStart"
     @touchend="onTouchEnd"
     @touchcancel="onTouchEnd"
@@ -108,7 +108,9 @@ onUnmounted(() => {
     @mouseup="onMouseUp"
     @mouseenter="onMouseEnter"
     @mouseleave="onMouseLeave"
-  ></td>
+    >
+    <slot></slot>
+  </td>
 </template>
 
 <style scoped>

--- a/src/stores/state.ts
+++ b/src/stores/state.ts
@@ -24,6 +24,10 @@ export const useStateStore = defineStore('state', () => {
   const centsFractionDigits = ref(parseInt(storage.getItem('centsFractionDigits') ?? '3', 10))
   const decimalFractionDigits = ref(parseInt(storage.getItem('decimalFractionDigits') ?? '5', 10))
   const showVirtualQwerty = ref(storage.getItem('showVirtualQwerty') === 'true')
+  const showKeyboardLabel = ref(storage.getItem('showKeyboardLabel') !== 'false')
+  const showKeyboardCents = ref(storage.getItem('showKeyboardCents') !== 'false')
+  const showKeyboardRatio = ref(storage.getItem('showKeyboardRatio') !== 'false')
+  const showKeyboardFrequency = ref(storage.getItem('showKeyboardFrequency') !== 'false')
 
   // Analysis preferences
   const intervalMatrixIndexing = ref(parseInt(storage.getItem('intervalMatrixIndexing') ?? '0', 10))
@@ -50,6 +54,10 @@ export const useStateStore = defineStore('state', () => {
     centsFractionDigits,
     decimalFractionDigits,
     showVirtualQwerty,
+    showKeyboardLabel,
+    showKeyboardCents,
+    showKeyboardRatio,
+    showKeyboardFrequency,
     intervalMatrixIndexing,
     maxMatrixWidth,
     calculateConstantStructureViolations,
@@ -84,6 +92,10 @@ export const useStateStore = defineStore('state', () => {
     centsFractionDigits,
     decimalFractionDigits,
     showVirtualQwerty,
+    showKeyboardLabel,
+    showKeyboardCents,
+    showKeyboardRatio,
+    showKeyboardFrequency,
     intervalMatrixIndexing,
     maxMatrixWidth,
     calculateConstantStructureViolations,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -248,6 +248,10 @@ export function autoKeyColors(size: number) {
   return result
 }
 
+export function formatCents(x: number, fractionDigits = 3) {
+  return formatExponential(x, fractionDigits) + '¢'
+}
+
 /**
  * Fill in the gaps of a parent scale (in white) with accidentals (in black).
  * @param generatorPerPeriod Generator sizre divided by period size (in pitch space).

--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -52,6 +52,7 @@ const tagline = computed(() => TAGLINES[Math.floor(Math.random() * TAGLINES.leng
         Forrest Cahoon - <i>developer</i> <br />
         Videco - <i>developer</i> <br />
         Inthar - <i>developer</i> <br />
+        Wilckerson Ganda - <i>developer</i> <br />
         Kraig Grady - <i>lattice advisor</i> <br />
         Abnormality - <i>quality assurance</i> <br />
         Kite Giedraitis - <i>notation advisor</i> <br />

--- a/src/views/SynthView.vue
+++ b/src/views/SynthView.vue
@@ -454,6 +454,31 @@ onUnmounted(() => {
           </template>
         </div>
         <template v-if="scale.keyboardMode === 'isomorphic'">
+          <h2>Keyboard notes</h2>
+          <div class="control-group" style="flex-direction: row; flex-wrap: wrap">
+            <div class="control checkbox-container">
+              <input id="keyboard-show-label" type="checkbox" v-model="state.showKeyboardLabel" />
+              <label for="keyboard-show-label">Display label</label>
+            </div>
+            <div class="control checkbox-container">
+              <input id="keyboard-show-cents" type="checkbox" v-model="state.showKeyboardCents" />
+              <label for="keyboard-show-cents">Display cents</label>
+            </div>
+            <div class="control checkbox-container">
+              <input id="keyboard-show-ratio" type="checkbox" v-model="state.showKeyboardRatio" />
+              <label for="keyboard-show-ratio">Display ratio</label>
+            </div>
+            <div class="control checkbox-container">
+              <input
+                id="keyboard-show-frequency"
+                type="checkbox"
+                v-model="state.showKeyboardFrequency"
+              />
+              <label for="keyboard-show-frequency">Display frequency</label>
+            </div>
+          </div>
+        </template>
+        <template v-if="scale.keyboardMode === 'isomorphic'">
           <h2>Isomorphic key mapping</h2>
           <p>
             Distance between adjacent keys on the horizontal/vertical axes, in scale degrees.

--- a/src/views/VirtualKeyboardView.vue
+++ b/src/views/VirtualKeyboardView.vue
@@ -41,9 +41,17 @@ type NoteOnCallback = (index: number) => NoteOff
       :baseMidiNote="scale.baseMidiNote"
       :isomorphicHorizontal="state.isomorphicHorizontal"
       :isomorphicVertical="state.isomorphicVertical"
-      :keyColors="scale.colors"
+      :colorMap="scale.colorForIndex"
       :noteOn="noteOn"
       :heldNotes="state.heldNotes"
+      :baseFrequency="scale.baseFrequency"
+      :frequencies="scale.frequencies"
+      :centss="scale.centss"
+      :labelMap="scale.labelForIndex"
+      :showLabel="state.showKeyboardLabel"
+      :showCent="state.showKeyboardCents"
+      :showRatio="state.showKeyboardRatio"
+      :showFrequency="state.showKeyboardFrequency"
     ></VirtualKeyboard>
   </main>
 </template>


### PR DESCRIPTION
Hello everyone.

I have been using the Scale Workshop since V1 and I would like to congratulate you all for the amazing work and the new features added to each version.

I am a software developer and microtonal enthusiast as well, developing my own tools to explore this new musical world, like: 
[https://microtonal-keyboard.onrender.com](https://microtonal-keyboard.onrender.com)
[https://microtonal-tuner.onrender.com](https://microtonal-tuner.onrender.com)

However, I would like to start collaborating more with the existing tools in the community.

This PR is my contribution to handling the issue [#534](https://github.com/xenharmonic-devs/scale-workshop/issues/534) that I have been missing for a while. 

I have adjusted the code to display the label, ratio, cents, and frequency on the VirtualKeyboardKey considering the light/dark theme and the automatic colors. In a future PR, I am thinking of adding a left panel to the VirtualKeyboard page to allow the user to configure which of those info to display, and other related configurations, like the isomorphic vertical and horizontal values.

![image](https://github.com/xenharmonic-devs/scale-workshop/assets/5788370/724f0639-9044-42bd-b7ab-33b4c632cc11)
![image](https://github.com/xenharmonic-devs/scale-workshop/assets/5788370/6b656566-1e3b-4f33-a135-cc34e84f2fdd)
![image](https://github.com/xenharmonic-devs/scale-workshop/assets/5788370/086d577b-02ff-469d-ac87-3dc3b3f34dd7)

I hope this can be useful because I am excited to collaborate more with the project. Also, it would be awesome if this could be included in the V2 as well. 

Thank you. 
