### PR TITLE
Update sonic-weave and xen-dev-utils dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scale-workshop",
-  "version": "3.0.0-beta.16",
+  "version": "3.0.0-beta.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scale-workshop",
-      "version": "3.0.0-beta.16",
+      "version": "3.0.0-beta.17",
       "dependencies": {
         "isomorphic-qwerty": "^0.0.2",
         "ji-lattice": "^0.0.3",
@@ -14,14 +14,14 @@
         "moment-of-symmetry": "^0.4.2",
         "pinia": "^2.1.7",
         "qs": "^6.12.0",
-        "sonic-weave": "github:xenharmonic-devs/sonic-weave#v0.0.21",
+        "sonic-weave": "github:xenharmonic-devs/sonic-weave#v0.0.22",
         "sw-synth": "^0.1.0",
         "temperaments": "^0.5.3",
         "values.js": "^2.1.1",
         "vue": "^3.3.4",
         "vue-router": "^4.3.0",
         "webmidi": "^3.1.8",
-        "xen-dev-utils": "^0.2.9",
+        "xen-dev-utils": "^0.3.0",
         "xen-midi": "^0.2.0"
       },
       "devDependencies": {
@@ -3778,6 +3778,18 @@
         "url": "https://github.com/sponsors/frostburn"
       }
     },
+    "node_modules/ji-lattice/node_modules/xen-dev-utils": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/xen-dev-utils/-/xen-dev-utils-0.2.9.tgz",
+      "integrity": "sha512-ngs85djTa5MH9yMomyFg1ZK1eETgtaG6FN5ZvDazyBbGmShuK/gOEWGRemHqm+I2zp3lOGbXlEU/M4SwYl3HLA==",
+      "engines": {
+        "node": ">=10.6.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/frostburn"
+      }
+    },
     "node_modules/joi": {
       "version": "17.12.3",
       "resolved": "https://registry.npmjs.org/joi/-/joi-17.12.3.tgz",
@@ -4374,6 +4386,18 @@
       "integrity": "sha512-XBzU01kDgQfN0JacGSwMOxJOk5EhwcaojbDQDDdZF/k16ze/VP9X8Cz1Gy8Hmhg+WMu0axfTVP4ufzhoFt0C4g==",
       "dependencies": {
         "xen-dev-utils": "^0.2.8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/frostburn"
+      }
+    },
+    "node_modules/moment-of-symmetry/node_modules/xen-dev-utils": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/xen-dev-utils/-/xen-dev-utils-0.2.9.tgz",
+      "integrity": "sha512-ngs85djTa5MH9yMomyFg1ZK1eETgtaG6FN5ZvDazyBbGmShuK/gOEWGRemHqm+I2zp3lOGbXlEU/M4SwYl3HLA==",
+      "engines": {
+        "node": ">=10.6.0"
       },
       "funding": {
         "type": "github",
@@ -5443,12 +5467,12 @@
       }
     },
     "node_modules/sonic-weave": {
-      "version": "0.0.21",
-      "resolved": "git+ssh://git@github.com/xenharmonic-devs/sonic-weave.git#cc3ac1b25ad8d2289920df4b000f719b5c3439b1",
+      "version": "0.0.22",
+      "resolved": "git+ssh://git@github.com/xenharmonic-devs/sonic-weave.git#afd84002275dcd1e112a06694966ce8a1596a221",
       "license": "MIT",
       "dependencies": {
         "moment-of-symmetry": "^0.4.2",
-        "xen-dev-utils": "^0.2.9"
+        "xen-dev-utils": "^0.3.0"
       },
       "bin": {
         "sonic-weave": "bin/sonic-weave.js"
@@ -5764,6 +5788,18 @@
         "mathjs": "^12.4.0",
         "ts-geometric-algebra": "^0.5.1",
         "xen-dev-utils": "^0.2.7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/frostburn"
+      }
+    },
+    "node_modules/temperaments/node_modules/xen-dev-utils": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/xen-dev-utils/-/xen-dev-utils-0.2.9.tgz",
+      "integrity": "sha512-ngs85djTa5MH9yMomyFg1ZK1eETgtaG6FN5ZvDazyBbGmShuK/gOEWGRemHqm+I2zp3lOGbXlEU/M4SwYl3HLA==",
+      "engines": {
+        "node": ">=10.6.0"
       },
       "funding": {
         "type": "github",
@@ -6580,9 +6616,9 @@
       }
     },
     "node_modules/xen-dev-utils": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/xen-dev-utils/-/xen-dev-utils-0.2.9.tgz",
-      "integrity": "sha512-ngs85djTa5MH9yMomyFg1ZK1eETgtaG6FN5ZvDazyBbGmShuK/gOEWGRemHqm+I2zp3lOGbXlEU/M4SwYl3HLA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xen-dev-utils/-/xen-dev-utils-0.3.0.tgz",
+      "integrity": "sha512-yyAT+9fXeZ88JDGslx8MAc5tQOkXKaPKk9+9f3/w4V+tEM+U5aTwH0oy81Muv+UXUX/uBwe0ufIHMyIHeaIDQw==",
       "engines": {
         "node": ">=10.6.0"
       },
@@ -6598,6 +6634,18 @@
       "dependencies": {
         "webmidi": "^3.1.8",
         "xen-dev-utils": "^0.2.8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/frostburn"
+      }
+    },
+    "node_modules/xen-midi/node_modules/xen-dev-utils": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/xen-dev-utils/-/xen-dev-utils-0.2.9.tgz",
+      "integrity": "sha512-ngs85djTa5MH9yMomyFg1ZK1eETgtaG6FN5ZvDazyBbGmShuK/gOEWGRemHqm+I2zp3lOGbXlEU/M4SwYl3HLA==",
+      "engines": {
+        "node": ">=10.6.0"
       },
       "funding": {
         "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scale-workshop",
-  "version": "3.0.0-beta.16",
+  "version": "3.0.0-beta.17",
   "scripts": {
     "dev": "vite",
     "build": "run-p type-check \"build-only {@}\" --",
@@ -21,14 +21,14 @@
     "moment-of-symmetry": "^0.4.2",
     "pinia": "^2.1.7",
     "qs": "^6.12.0",
-    "sonic-weave": "github:xenharmonic-devs/sonic-weave#v0.0.21",
+    "sonic-weave": "github:xenharmonic-devs/sonic-weave#v0.0.22",
     "sw-synth": "^0.1.0",
     "temperaments": "^0.5.3",
     "values.js": "^2.1.1",
     "vue": "^3.3.4",
     "vue-router": "^4.3.0",
     "webmidi": "^3.1.8",
-    "xen-dev-utils": "^0.2.9",
+    "xen-dev-utils": "^0.3.0",
     "xen-midi": "^0.2.0"
   },
   "devDependencies": {

--- a/src/stores/scale.ts
+++ b/src/stores/scale.ts
@@ -395,11 +395,11 @@ export const useScaleStore = defineStore('scale', () => {
           )
         } else if (autoColors.value === 'cents') {
           colors.value = intervals.map(
-            (interval) => interval.color?.value ?? centsColor(interval).value
+            (interval) => interval.color?.value ?? centsColor.bind(ev)(interval).value
           )
         } else {
           colors.value = intervals.map(
-            (interval) => interval.color?.value ?? factorColor(interval).value
+            (interval) => interval.color?.value ?? factorColor.bind(ev)(interval).value
           )
         }
         labels.value = intervals.map((interval) => interval.label || name(interval))


### PR DESCRIPTION
Better type enforcement.
The product of gcd and lcm is the same as the product of the arguments.