### PR TITLE
Use SonicWeave scale title

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scale-workshop",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0-beta.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scale-workshop",
-      "version": "3.0.0-beta.17",
+      "version": "3.0.0-beta.18",
       "dependencies": {
         "isomorphic-qwerty": "^0.0.2",
         "ji-lattice": "^0.0.3",
@@ -14,7 +14,7 @@
         "moment-of-symmetry": "^0.4.2",
         "pinia": "^2.1.7",
         "qs": "^6.12.0",
-        "sonic-weave": "github:xenharmonic-devs/sonic-weave#v0.0.22",
+        "sonic-weave": "github:xenharmonic-devs/sonic-weave#v0.0.23",
         "sw-synth": "^0.1.0",
         "temperaments": "^0.5.3",
         "values.js": "^2.1.1",
@@ -5467,8 +5467,8 @@
       }
     },
     "node_modules/sonic-weave": {
-      "version": "0.0.22",
-      "resolved": "git+ssh://git@github.com/xenharmonic-devs/sonic-weave.git#afd84002275dcd1e112a06694966ce8a1596a221",
+      "version": "0.0.23",
+      "resolved": "git+ssh://git@github.com/xenharmonic-devs/sonic-weave.git#a22690092f8f5f117b5fc18894ed0c0a6ee5eee1",
       "license": "MIT",
       "dependencies": {
         "moment-of-symmetry": "^0.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scale-workshop",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0-beta.18",
   "scripts": {
     "dev": "vite",
     "build": "run-p type-check \"build-only {@}\" --",
@@ -21,7 +21,7 @@
     "moment-of-symmetry": "^0.4.2",
     "pinia": "^2.1.7",
     "qs": "^6.12.0",
-    "sonic-weave": "github:xenharmonic-devs/sonic-weave#v0.0.22",
+    "sonic-weave": "github:xenharmonic-devs/sonic-weave#v0.0.23",
     "sw-synth": "^0.1.0",
     "temperaments": "^0.5.3",
     "values.js": "^2.1.1",

--- a/src/character-palette.json
+++ b/src/character-palette.json
@@ -11,10 +11,8 @@
   "½": "Semi-prefix. E.g. G semisharp four <code>G½♯4</code>, semimajor third <code>½M3</code>, neutral sesquith <code>n1½</code>.",
   "¼": "Quarter-prefix. E.g. E quarter flat four <code>E¼♭4</code>.",
   "¾": "Sesqui-semi-prefix. E.g. D sesqui semisharp four <code>D¾♯4</code>.",
-  "⅛": "Eighth-prefix. E.g. Gamma eighth flat four <code>γ⅛♭4</code>.",
-  "⅜": "Three eighths-prefix. E.g. Three eighths diminished third and a halfth <code>⅜d3.5</code>.",
-  "⅝": "Five eighths-prefix.",
-  "⅞": "Seven eighths-prefix.",
+  "⅓": "One-third-prefix. E.g. Third-major second <code>⅓M2</code>.",
+  "⅔": "Two-thirds-prefix. E.g. E two-thirds flat four <code>E⅔♭4</code>.",
   "×": "Times symbol. E.g. <code>4/3 × 4/3</code> is <code>16/9</code>.",
   "÷": "Division symbol. E.g. <code>9/8 ÷ 81/80</code> is <code>10/9</code>.",
   "·": "Dot product. E.g. <code>3/2 · 12@</code> is <code>7</code> i.e. a fifth is seven steps of 12-tone equal temperament.",
@@ -34,7 +32,9 @@
   "ω": "Semiquartal nominal omega. <code>ω4</code> is a semifourth below <code>D5</code>.",
   "¤": "Semiquartal accidental scarab ≈ +158.8¢. <code>F¤4</code> is a semifourth below <code>A4</code>.",
   "£": "Semiquartal accidental pound ≈ -158.8¢. <code>A£4</code> is a semifourth above <code>F4</code>.",
-  "¢": "Cent. <code>¢</code> is equal to <code>1\\1200</code>.",
-  "€": "Reciprocal cent. <code>¢ · €</code> is <code>1</code>.",
-  "µ": "Metric prefix micro. E.g. Period of oscillation <code>2000 µs</code> corresponds to frequency of oscillation <code>500 Hz</code>."
+  "¢": "Cent. <code>1¢</code> is equal to <code>1\\1200</code>.",
+  "€": "Reciprocal cent. <code>1¢ · €</code> is <code>1</code>.",
+  "µ": "Metric prefix micro. E.g. Period of oscillation <code>2000 µs</code> corresponds to frequency of oscillation <code>500 Hz</code>.",
+  "⟨": "Val angle bracket. <code>⟨12 19 28]</code>.",
+  "⟩": "Monzo angle bracket. <code>[-4 4 -1⟩</code>."
 }

--- a/src/components/ExporterButtons.vue
+++ b/src/components/ExporterButtons.vue
@@ -42,14 +42,13 @@ function copyToClipboard() {
 function doExport(exporter: ExporterKey) {
   const params: ExporterParams = {
     newline: state.newline,
-    name: scale.name,
     scaleUrl: window.location.href,
-    filename: sanitizeFilename(scale.name),
+    filename: sanitizeFilename(scale.scale.title),
     relativeIntervals: scale.relativeIntervals,
     scale: scale.scale,
     labels: scale.labels,
     midiOctaveOffset: -1,
-    description: scale.name,
+    description: scale.scale.title,
     sourceText: scale.sourceText,
     appTitle: APP_TITLE,
     date: new Date()
@@ -65,7 +64,6 @@ function doExport(exporter: ExporterKey) {
       @confirm="showKorgExportModal = false"
       @cancel="showKorgExportModal = false"
       :newline="state.newline"
-      :scaleName="scale.name"
       :relativeIntervals="scale.relativeIntervals"
       :midiOctaveOffset="-1"
       :scale="scale.scale"
@@ -77,7 +75,6 @@ function doExport(exporter: ExporterKey) {
       @confirm="showMtsSysexExportModal = false"
       @cancel="showMtsSysexExportModal = false"
       :newline="state.newline"
-      :scaleName="scale.name"
       :relativeIntervals="scale.relativeIntervals"
       :midiOctaveOffset="-1"
       :scale="scale.scale"
@@ -89,7 +86,6 @@ function doExport(exporter: ExporterKey) {
       @confirm="showReaperExportModal = false"
       @cancel="showReaperExportModal = false"
       :newline="state.newline"
-      :scaleName="scale.name"
       :relativeIntervals="scale.relativeIntervals"
       :midiOctaveOffset="-1"
       :scale="scale.scale"

--- a/src/components/modals/export/KorgExport.vue
+++ b/src/components/modals/export/KorgExport.vue
@@ -9,7 +9,6 @@ import type { Scale } from '@/scale'
 
 const props = defineProps<{
   newline: string
-  scaleName: string
   midiOctaveOffset: number
   relativeIntervals: Interval[]
   labels: string[]
@@ -48,7 +47,7 @@ async function doExport() {
     scale: props.scale,
     relativeIntervals: props.relativeIntervals,
     labels: props.labels,
-    filename: sanitizeFilename(props.scaleName),
+    filename: sanitizeFilename(props.scale.title),
     midiOctaveOffset: props.midiOctaveOffset
   }
 

--- a/src/components/modals/export/MtsSysexExport.vue
+++ b/src/components/modals/export/MtsSysexExport.vue
@@ -10,7 +10,6 @@ import type { Interval } from 'sonic-weave'
 
 const props = defineProps<{
   newline: string
-  scaleName: string
   midiOctaveOffset: number
   relativeIntervals: Interval[]
   scale: Scale
@@ -27,14 +26,14 @@ function clampName(name: string): string {
   return name.slice(0, 16)
 }
 
-const name = ref(clampName(props.scaleName))
+const name = ref(clampName(props.scale.title))
 
 function nameInputCallback(nameInput: string): void {
   name.value = clampName(nameInput)
 }
 
 watch(
-  () => props.scaleName,
+  () => props.scale.title,
   (newName) => nameInputCallback(newName),
   { immediate: true }
 )
@@ -55,11 +54,10 @@ function doExport() {
   const params: ExporterParams = {
     newline: props.newline,
     scale: props.scale,
-    filename: sanitizeFilename(props.scaleName),
+    filename: sanitizeFilename(props.scale.title),
     relativeIntervals: props.relativeIntervals,
     midiOctaveOffset: props.midiOctaveOffset,
     labels: props.labels,
-    name: name.value,
     presetIndex: parseInt(presetIndex.value)
   }
 

--- a/src/components/modals/export/ReaperExport.vue
+++ b/src/components/modals/export/ReaperExport.vue
@@ -9,7 +9,6 @@ import type { Interval } from 'sonic-weave'
 
 const props = defineProps<{
   newline: string
-  scaleName: string
   midiOctaveOffset: number
   relativeIntervals: Interval[]
   scale: Scale
@@ -36,7 +35,7 @@ function doExport() {
   const params: ExporterParams = {
     newline: props.newline,
     scale: props.scale,
-    filename: sanitizeFilename(props.scaleName),
+    filename: sanitizeFilename(props.scale.title),
     midiOctaveOffset: props.midiOctaveOffset,
     relativeIntervals: props.relativeIntervals,
     labels: props.labels,

--- a/src/components/modals/generation/StackSteps.vue
+++ b/src/components/modals/generation/StackSteps.vue
@@ -21,7 +21,7 @@ function computeTotal() {
 const updateTotal = debounce(computeTotal)
 
 function generate(expand = true) {
-  const source = scaleData.value + '\nstack()\ni => simplify(i) if isLinear(i) else i'
+  const source = scaleData.value + '\nstack()'
   if (expand) {
     emit('update:source', expandCode(source))
   } else {

--- a/src/exporters/__tests__/korg.spec.ts
+++ b/src/exporters/__tests__/korg.spec.ts
@@ -11,11 +11,11 @@ import { Interval, TimeReal } from 'sonic-weave'
 describe('Korg exporters', () => {
   it('can export a scale encountered while debugging issue #393', async () => {
     const params = getTestData("Korg 'logue exporter unit test")
-    params.baseMidiNote = 60
     params.scale = new Scale(
       [...Array(12).keys()].map((i) => 24 / (23 - i)),
       256,
-      60
+      60,
+      'Test Scale'
     )
 
     const exporter = new KorgExporter(params, KorgModels.MINILOGUE, false)
@@ -86,7 +86,7 @@ describe('Korg exporters', () => {
     params.relativeIntervals.push(new Interval(TimeReal.fromCents(100.0), 'logarithmic'))
     params.sourceText += '\n100.'
     const ratios = params.relativeIntervals.map((i) => i.value.valueOf())
-    params.scale = new Scale(ratios, 440, 69)
+    params.scale = new Scale(ratios, 440, 69, 'Test Scale')
     expect(() => new KorgExporter(params, KorgModels.MINILOGUE, true)).toThrowError(
       KorgExporterError.OCTAVE_INVALID_EQUAVE
     )
@@ -110,7 +110,7 @@ describe('Korg exporters', () => {
       params.sourceText += '100.\n' + params.sourceText
     }
     const ratios = params.relativeIntervals.map((i) => i.value.valueOf())
-    params.scale = new Scale(ratios, 440, 69)
+    params.scale = new Scale(ratios, 440, 69, 'Test Scale')
 
     expect(() => new KorgExporter(params, KorgModels.MINILOGUE, true)).toThrowError(
       KorgExporterError.OCTAVE_INVALID_INTERVAL
@@ -127,7 +127,7 @@ describe('Korg exporters', () => {
       params.sourceText += '100.\n' + params.sourceText
     }
     const ratios = params.relativeIntervals.map((i) => i.value.valueOf())
-    params.scale = new Scale(ratios, 440, 69)
+    params.scale = new Scale(ratios, 440, 69, 'Test Scale')
 
     expect(() => new KorgExporter(params, KorgModels.MINILOGUE, true)).toThrowError(
       KorgExporterError.OCTAVE_INVALID_INTERVAL
@@ -143,7 +143,7 @@ describe('Korg exporters', () => {
       params.sourceText += '100.\n' + params.sourceText
     }
     const ratios = params.relativeIntervals.map((i) => i.value.valueOf())
-    params.scale = new Scale(ratios, 440, 69)
+    params.scale = new Scale(ratios, 440, 69, 'Test Scale')
 
     const exporter = new KorgExporter(params, KorgModels.MINILOGUE, true)
     const [zip, fileType] = exporter.getFileContents()

--- a/src/exporters/__tests__/mts.spec.ts
+++ b/src/exporters/__tests__/mts.spec.ts
@@ -28,7 +28,7 @@ describe('MTS exporter', () => {
 
   it('can gracefully handle invalid parameters', async () => {
     const params = getTestData('MTS Sysex Bulk Tuning Dump exporter unit test v0.0.0')
-    params.name = 'Super Special Test Scale'
+    params.scale.title = 'Super Special Test Scale'
     params.presetIndex = -1
 
     const exporter = new MtsSysexExporter(params)

--- a/src/exporters/__tests__/test-data.ts
+++ b/src/exporters/__tests__/test-data.ts
@@ -68,12 +68,11 @@ export function getTestData(appTitle: string) {
     })
   ]
   const ratios = relativeIntervals.map((i) => i.value.valueOf())
-  const scale = new Scale(ratios, 440, 69)
+  const scale = new Scale(ratios, 440, 69, 'Test Scale')
   const params: ExporterParams = {
     filename: 'test',
     newline: process.platform === 'linux' ? UNIX_NEWLINE : WINDOWS_NEWLINE,
     scaleUrl: 'https://scaleworkshop.plainsound.org/',
-    name: 'Test Scale',
     relativeIntervals,
     scale,
     appTitle,

--- a/src/exporters/ableton.ts
+++ b/src/exporters/ableton.ts
@@ -11,7 +11,7 @@ export default class AbletonAsclExporter extends BaseExporter {
 
   constructor(params: ExporterParams) {
     super(params)
-    this.name = params.name || 'Untitled tuning'
+    this.name = params.scale.title || 'Untitled tuning'
     this.appTitle = params.appTitle || APP_TITLE
   }
 

--- a/src/exporters/anamark.ts
+++ b/src/exporters/anamark.ts
@@ -34,7 +34,7 @@ class AnaMarkExporter extends BaseExporter {
 
     // Comment section
     let file = '; VAZ Plus/AnaMark softsynth tuning file' + newline
-    file += '; ' + this.params.name + newline
+    file += '; ' + this.params.scale.title + newline
     file += ';' + newline
 
     // If version 200 or higher, display the scale URL so user can easily get back to the original scale that generates this tun file.

--- a/src/exporters/base.ts
+++ b/src/exporters/base.ts
@@ -10,7 +10,6 @@ export type ExporterParams = {
   midiOctaveOffset: number
   scale: Scale
   labels: string[]
-  name?: string
   scaleUrl?: string
   description?: string
   sourceText?: string // May contain invalid lines

--- a/src/exporters/kontakt.ts
+++ b/src/exporters/kontakt.ts
@@ -23,7 +23,7 @@ export default class KontaktExporter extends BaseExporter {
 
     // assemble the kontakt script contents
     let file = '{**************************************' + newline
-    file += this.params.name + newline
+    file += this.params.scale.title + newline
     file +=
       'MIDI note ' +
       baseMidiNote.toString() +

--- a/src/exporters/korg.ts
+++ b/src/exporters/korg.ts
@@ -178,7 +178,7 @@ export class KorgExporter extends BaseExporter {
     const tuningInfo = this.getTuningInfoXml(
       this.modelName,
       'ScaleWorkshop',
-      this.params.name ?? ''
+      scale.title
     )
     const fileInfo = this.getFileInfoXml(this.modelName)
     const [fileNameHeader, fileType] = this.useOctaveFormat

--- a/src/exporters/max-msp.ts
+++ b/src/exporters/max-msp.ts
@@ -17,7 +17,7 @@ export default class MaxMSPExporter extends BaseExporter {
       '# Tuning file for Max/MSP coll objects. - Created using ' +
       this.appTitle +
       this.params.newline
-    file += '# ' + this.params.name + this.params.newline
+    file += '# ' + this.params.scale.title + this.params.newline
     file += '#' + this.params.newline
     file += '# ' + this.params.scaleUrl + this.params.newline
     file += '#' + this.params.newline

--- a/src/exporters/mts-sysex.ts
+++ b/src/exporters/mts-sysex.ts
@@ -34,7 +34,7 @@ export default class MtsSysexExporter extends BaseExporter {
   }
 
   getNameData() {
-    let name = this.params.name ?? ''
+    let name = this.params.scale.title
     while (name.length < 16) {
       name += ' '
     }

--- a/src/exporters/scala.ts
+++ b/src/exporters/scala.ts
@@ -9,7 +9,7 @@ export class ScalaSclExporter extends BaseExporter {
 
   constructor(params: ExporterParams) {
     super(params)
-    this.name = params.name || 'Untitled tuning'
+    this.name = params.scale.title || 'Untitled tuning'
     this.appTitle = params.appTitle || APP_TITLE
   }
 

--- a/src/scale.ts
+++ b/src/scale.ts
@@ -5,6 +5,7 @@ export class Scale {
   intervalRatios: number[]
   baseFrequency: number
   baseMidiNote: number
+  title: string
 
   /**
    * Construct a new musical scale.
@@ -12,10 +13,11 @@ export class Scale {
    * @param baseFrequency Base frequency of 1/1.
    * @param baseMidiNote MIDI note corresponfing to base frequency
    */
-  constructor(intervalRatios: number[], baseFrequency: number, baseMidiNote: number) {
+  constructor(intervalRatios: number[], baseFrequency: number, baseMidiNote: number, title: string) {
     this.intervalRatios = intervalRatios
     this.baseFrequency = baseFrequency
     this.baseMidiNote = baseMidiNote
+    this.title = title
   }
 
   /** Number of intervals in the scale. */

--- a/src/stores/scale.ts
+++ b/src/stores/scale.ts
@@ -63,6 +63,7 @@ export const useScaleStore = defineStore('scale', () => {
   // Computational budget to prevent tab hanging.
   const gas = ref(parseInt(localStorage.getItem('gas') ?? '10000', 10))
 
+  // The title the user inputs in the textarea. May be overridden in the source.
   const name = ref('')
   // For the v-model. Consider stores.scale.scale.baseMidiNote the source of truth.
   const baseMidiNote = ref(60)
@@ -83,7 +84,7 @@ export const useScaleStore = defineStore('scale', () => {
     }
   })
   // XXX: baseFrequencyDisplay is merely used for convenience here. This is the last time there's a direct connection.
-  const scale = ref(new Scale(TET12, baseFrequencyDisplay.value, baseMidiNote.value))
+  const scale = ref(new Scale(TET12, baseFrequencyDisplay.value, baseMidiNote.value, name.value))
   const autoColors = ref<'silver' | 'cents' | 'factors'>('silver')
   const sourceText = ref('')
   const relativeIntervals = ref(INTERVALS_12TET)
@@ -110,7 +111,7 @@ export const useScaleStore = defineStore('scale', () => {
 
   // === Computed state ===
   const sourcePrefix = computed(() => {
-    const base = `numComponents(${DEFAULT_NUMBER_OF_COMPONENTS})\n`
+    const base = `${JSON.stringify(name.value)}\nnumComponents(${DEFAULT_NUMBER_OF_COMPONENTS})\n`
     const rootPitch = midiNoteNumberToName(baseMidiNote.value)
     if (autoFrequency.value) {
       return `${base}${rootPitch} = mtof(_) = 1/1`
@@ -387,7 +388,7 @@ export const useScaleStore = defineStore('scale', () => {
       }
       if (ratios.length) {
         const name = str.bind(ev)
-        scale.value = new Scale(ratios, visitorBaseFrequency, baseMidiNote.value)
+        scale.value = new Scale(ratios, visitorBaseFrequency, baseMidiNote.value, ev.rootContext!.title)
         if (autoColors.value === 'silver') {
           colors.value = intervals.map(
             (interval, i) =>
@@ -404,7 +405,7 @@ export const useScaleStore = defineStore('scale', () => {
         }
         labels.value = intervals.map((interval) => interval.label || name(interval))
       } else {
-        scale.value = new Scale(TET12, visitorBaseFrequency, baseMidiNote.value)
+        scale.value = new Scale(TET12, visitorBaseFrequency, baseMidiNote.value, name.value)
         colors.value = defaultColors(baseMidiNote.value)
         labels.value = defaultLabels(baseMidiNote.value, accidentalPreference.value)
         warning.value = 'Empty scale defaults to 12-tone equal temperament.'


### PR DESCRIPTION
Use the scale title provided by SonicWeave on export. Rely on new linear simplification behavior in stack steps. Update sonic-weave dependency.
SonicWeave change log:
- Add support for fancy angle brackets in monzos and vals
- Make harmonic segments part of chord enumerations
- Fix down expressions
- Auto-simplify universal linear multiplication
- Implement character code string methods
- Make vees legal in FJS
- Make tempering a binary operator
- Broadcast operators over arrays of vals

ref #664