### PR TITLE
Update sonic-weave dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scale-workshop",
-  "version": "3.0.0-beta.22",
+  "version": "3.0.0-beta.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scale-workshop",
-      "version": "3.0.0-beta.22",
+      "version": "3.0.0-beta.23",
       "dependencies": {
         "isomorphic-qwerty": "^0.0.2",
         "ji-lattice": "^0.0.3",
@@ -14,7 +14,7 @@
         "moment-of-symmetry": "^0.4.2",
         "pinia": "^2.1.7",
         "qs": "^6.12.0",
-        "sonic-weave": "github:xenharmonic-devs/sonic-weave#v0.0.31",
+        "sonic-weave": "github:xenharmonic-devs/sonic-weave#v0.0.33",
         "sw-synth": "^0.1.0",
         "temperaments": "^0.5.3",
         "values.js": "^2.1.1",
@@ -5467,8 +5467,8 @@
       }
     },
     "node_modules/sonic-weave": {
-      "version": "0.0.31",
-      "resolved": "git+ssh://git@github.com/xenharmonic-devs/sonic-weave.git#45165dbeb10765c0ce02185ab3c57003d3f94c8e",
+      "version": "0.0.33",
+      "resolved": "git+ssh://git@github.com/xenharmonic-devs/sonic-weave.git#65dfd269eb349e68f02e1d5764b0a79ad6bd42fa",
       "license": "MIT",
       "dependencies": {
         "moment-of-symmetry": "^0.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scale-workshop",
-  "version": "3.0.0-beta.22",
+  "version": "3.0.0-beta.23",
   "scripts": {
     "dev": "vite",
     "build": "run-p type-check \"build-only {@}\" --",
@@ -21,7 +21,7 @@
     "moment-of-symmetry": "^0.4.2",
     "pinia": "^2.1.7",
     "qs": "^6.12.0",
-    "sonic-weave": "github:xenharmonic-devs/sonic-weave#v0.0.31",
+    "sonic-weave": "github:xenharmonic-devs/sonic-weave#v0.0.33",
     "sw-synth": "^0.1.0",
     "temperaments": "^0.5.3",
     "values.js": "^2.1.1",

--- a/src/exporters/__tests__/test-data.ts
+++ b/src/exporters/__tests__/test-data.ts
@@ -28,7 +28,9 @@ export function getTestData(appTitle: string) {
       type: 'CentsLiteral',
       sign: '',
       whole: 100n,
-      fractional: ''
+      fractional: '',
+      exponent: null,
+      real: false,
     }),
     relativeC5,
     new Interval(

--- a/src/presets.json
+++ b/src/presets.json
@@ -228,7 +228,7 @@
   },
   "17rast": {
     "name": "17edo Rast",
-    "source": "M2 white\nn3 gray\nP4 white\nP5 white\nM6 white\nn7 gray\nP8 white\nmap(str)\n17@\n",
+    "source": "defer 17@\nM2 white\nn3 gray\nP4 white\nP5 white\nM6 white\nn7 gray\nP8 white\nmap(str)\n",
     "categories": ["MOS", "equal temperament"]
   },
   "22porcupine8": {
@@ -260,7 +260,7 @@
   },
   "31meantone19": {
     "name": "31edo meantone[19]",
-    "source": "A♮4 = 440 Hz\nA♯4 navy\nB♭4 maroon\nB♮4 white\nC♭5 maroon\nC♮5 white\nC♯5 navy\nD♭5 maroon\nD♮5 white\nD♯5 navy\nE♭5 maroon\nE♮5 white\nE♯5 navy\nF♮5 white\nF♯5 navy\nG♭5 maroon\nG♮5 white\nG♯5 navy\nA♭5 maroon\nA♮5 white\nmap(i => str(i)[..1])\n31@\n",
+    "source": "defer 31@\ndefer map(i => str(i)[..1])\nA♮4 = 440 Hz\nA♯4 navy\nB♭4 maroon\nB♮4 white\nC♭5 maroon\nC♮5 white\nC♯5 navy\nD♭5 maroon\nD♮5 white\nD♯5 navy\nE♭5 maroon\nE♮5 white\nE♯5 navy\nF♮5 white\nF♯5 navy\nG♭5 maroon\nG♮5 white\nG♯5 navy\nA♭5 maroon\nA♮5 white\n",
     "categories": ["MOS", "equal temperament"]
   },
   "46sensi11": {
@@ -275,7 +275,7 @@
   },
   "bohlenpierceeq": {
     "name": "Bohlen-Pierce equal (13ed3)",
-    "source": "27/25 black 'C♯/D♭'\n25/21 white 'D'\n9/7 white 'E'\n7/5 white 'F'\n75/49 black 'F♯/G♭'\n5/3 white 'G'\n9/5 white 'H'\n49/25 black 'H♯/J♭'\n15/7 white 'J'\n7/3 white 'A'\n63/25 black 'A♯/B♭'\n25/9 white 'B'\n3/1 white 'C'\nb13@\n",
+    "source": "defer b13@\n27/25 black 'C♯/D♭'\n25/21 white 'D'\n9/7 white 'E'\n7/5 white 'F'\n75/49 black 'F♯/G♭'\n5/3 white 'G'\n9/5 white 'H'\n49/25 black 'H♯/J♭'\n15/7 white 'J'\n7/3 white 'A'\n63/25 black 'A♯/B♭'\n25/9 white 'B'\n3/1 white 'C'\n",
     "categories": ["non-octave", "equal temperament"]
   },
   "bohlenpierceji": {

--- a/src/stores/scale.ts
+++ b/src/stores/scale.ts
@@ -328,9 +328,7 @@ export const useScaleStore = defineStore('scale', () => {
 
     // Declare base nominal and unison frequency
     const prefixAst = parseAST(sourcePrefix.value)
-    for (const statement of prefixAst.body) {
-      visitor.visit(statement)
-    }
+    visitor.executeProgram(prefixAst)
 
     return visitor
   }
@@ -344,12 +342,7 @@ export const useScaleStore = defineStore('scale', () => {
     defaults.gas = gas.value
 
     const ast = parseAST(sourceText.value)
-    for (const statement of ast.body) {
-      const interupt = visitor.visit(statement)
-      if (interupt) {
-        throw new Error('Illegal statement.')
-      }
-    }
+    visitor.executeProgram(ast);
     return {
       defaults,
       visitor
@@ -365,14 +358,12 @@ export const useScaleStore = defineStore('scale', () => {
       const visitor = new StatementVisitor(globalVisitor)
       visitor.isUserRoot = true;
       const ast = parseAST(sourceText.value)
+      visitor.executeProgram(ast);
       let userDeclaredPitch = false
       for (const statement of ast.body) {
         if (statement.type === 'PitchDeclaration') {
           userDeclaredPitch = true
-        }
-        const interupt = visitor.visit(statement)
-        if (interupt) {
-          throw new Error('Illegal statement.')
+          break
         }
       }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -62,12 +62,7 @@ export function expandCode(source: string) {
   const visitor = getSourceVisitor()
   const defaults = visitor.rootContext!.clone()
   const ast = parseAST(source)
-  for (const statement of ast.body) {
-    const interupt = visitor.visit(statement)
-    if (interupt) {
-      throw new Error('Illegal statement.')
-    }
-  }
+  visitor.executeProgram(ast);
   return visitor.expand(defaults)
 }
 


### PR DESCRIPTION
Use new program execution API.
Use new `defer` feature in some of the presets.

SonicWeave changelog:
- Re-enable irrational ranges
- Restrict bra-ket syntax (`dot`)
- Reserve `~dot` for non-strict dot products
- Replace `??` with `al`
- Shorten `===` to `==`
- Replace `!==` with `<>`
- Implement deferred actions
- Implement arithmetically accumulative repetition
- Implement `vdot` and `mdot`
- Implement matrix transposition
- Implement conversion between arrays, monzos and vals
- Implement a helper for extracting the domain of an interval
- Add helpers for inlining throwing and assertions
- Add `sof` as an alternative for the binary backslash
- Implement `weilHeight` utility