### PR TITLE
Update sonic-weave dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scale-workshop",
-  "version": "3.0.0-beta.37",
+  "version": "3.0.0-beta.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scale-workshop",
-      "version": "3.0.0-beta.37",
+      "version": "3.0.0-beta.38",
       "dependencies": {
         "harmonic-entropy": "^0.2.0",
         "isomorphic-qwerty": "^0.0.2",
@@ -15,7 +15,7 @@
         "moment-of-symmetry": "^0.8.0",
         "pinia": "^2.1.7",
         "qs": "^6.12.0",
-        "sonic-weave": "*",
+        "sonic-weave": "0.4.0",
         "sw-synth": "^0.1.0",
         "temperaments": "^0.5.3",
         "values.js": "^2.1.1",
@@ -5490,9 +5490,9 @@
       }
     },
     "node_modules/sonic-weave": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/sonic-weave/-/sonic-weave-0.3.4.tgz",
-      "integrity": "sha512-6AriXviwWUf48J/4KbJNHE0Riabh8hoTRSzoLCVo07LeRLEWJnvbF55+Xk/uH0w28iMzn17T7gaVanPsNppFfA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/sonic-weave/-/sonic-weave-0.4.0.tgz",
+      "integrity": "sha512-3P+BrDD4/axGknGeYlh6qbnS1ApSdywjynrvS+As0iiGt8cOl4BbYnoaboC10t0mwmCb4bKMZovIlJKA34qtjQ==",
       "dependencies": {
         "moment-of-symmetry": "^0.8.0",
         "xen-dev-utils": "^0.8.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scale-workshop",
-  "version": "3.0.0-beta.37",
+  "version": "3.0.0-beta.38",
   "scripts": {
     "dev": "vite",
     "build": "run-p type-check \"build-only {@}\" --",
@@ -22,7 +22,7 @@
     "moment-of-symmetry": "^0.8.0",
     "pinia": "^2.1.7",
     "qs": "^6.12.0",
-    "sonic-weave": "*",
+    "sonic-weave": "0.4.0",
     "sw-synth": "^0.1.0",
     "temperaments": "^0.5.3",
     "values.js": "^2.1.1",

--- a/src/character-palette.json
+++ b/src/character-palette.json
@@ -13,6 +13,7 @@
   "¾": "Sesqui-semi-prefix. E.g. D sesqui semisharp four <code>D¾♯4</code>.",
   "⅓": "One-third-prefix. E.g. Third-major second <code>⅓M2</code>.",
   "⅔": "Two-thirds-prefix. E.g. E two-thirds flat four <code>E⅔♭4</code>.",
+  "£": "Popped scale. E.g. <code>£ rdc £[-1]</code> reduces all intervals in your scale by the equave.",
   "×": "Times symbol. E.g. <code>4/3 × 4/3</code> is <code>16/9</code>.",
   "÷": "Division symbol. E.g. <code>9/8 ÷ 81/80</code> is <code>10/9</code>.",
   "·": "Dot product. E.g. <code>12@ · 3/2</code> is <code>7</code> i.e. a fifth is seven steps of 12-tone equal temperament.",

--- a/src/components/modals/generation/EnumerateChord.vue
+++ b/src/components/modals/generation/EnumerateChord.vue
@@ -12,7 +12,7 @@ function generate(expand = true) {
     let source = modal.chordIntervals.map((i) => i.toString()).join(':')
     emit('update:scaleName', `Chord ${modal.chord}`)
     if (modal.retrovertChord) {
-      source = `retroverted(${source})`
+      source = `retrovert(${source})`
     }
     if (expand) {
       emit('update:source', expandCode(source))

--- a/src/components/modals/modification/EnumerateScale.vue
+++ b/src/components/modals/modification/EnumerateScale.vue
@@ -43,7 +43,7 @@ function retroversion() {
   if (scale.sourceText) {
     scale.sourceText += '\n'
   }
-  scale.sourceText += 'retroverted(' + tones.join(':') + ')'
+  scale.sourceText += 'retrovert(' + tones.join(':') + ')'
   scale.computeScale()
   emit('done')
 }
@@ -57,7 +57,7 @@ function revposition() {
   if (scale.sourceText) {
     scale.sourceText += '\n'
   }
-  scale.sourceText += 'revposed(' + tones.join(':') + ')'
+  scale.sourceText += 'revpose(' + tones.join(':') + ')'
   scale.computeScale()
   emit('done')
 }

--- a/src/presets.json
+++ b/src/presets.json
@@ -141,7 +141,7 @@
   },
   "werckmeisteriii": {
     "name": "Werckmeister III (1691)",
-    "source": "{\n  const pythComma = aa1 - M2\n  const flatFif = P5 - pythComma / 4\n  P5 white 'C'\n  P5 white 'G'\n  flatFif white 'D'\n  P5 white 'A'\n  P5 white 'E'\n  P5 white 'B'\n  P5 black 'F♯'\n  P5 black 'C♯'\n  P5 black 'G♯'\n  flatFif black 'D♯'\n  flatFif black 'A♯'\n  stack()\n  P8 white 'F'\n  reduce()\n  sort()\n  i => cents(i, 3)\n}\n",
+    "source": "{\n  const pythComma = aa1 - M2\n  const flatFif = P5 - pythComma / 4\n  P5 white 'C'\n  P5 white 'G'\n  flatFif white 'D'\n  P5 white 'A'\n  P5 white 'E'\n  P5 white 'B'\n  P5 black 'F♯'\n  P5 black 'C♯'\n  P5 black 'G♯'\n  flatFif black 'D♯'\n  flatFif black 'A♯'\n  stack()\n  P8 white 'F'\n  reduce()\n  sort()\n  cents(£, 3)\n}\n",
     "categories": ["traditional"],
     "baseMidiNote": 65,
     "baseFrequency": 349
@@ -310,7 +310,7 @@
   },
   "otonalstacks": {
     "name": "Sevish stacked otonal framents",
-    "source": "unstacked(24 white:27:30:32:36)\nunstacked(24 lightblue:27:28:32:36)\nunstacked(24 palegoldenrod:27:30:32:36)\nstack()\n",
+    "source": "unstack(24 white:27:30:32:36)\nunstack(24 lightblue:27:28:32:36)\nunstack(24 palegoldenrod:27:30:32:36)\nstack()\n",
     "categories": ["non-octave", "just intonation"]
   },
   "blackdye": {

--- a/src/views/MosView.vue
+++ b/src/views/MosView.vue
@@ -71,9 +71,9 @@ function done() {
   router.push('/')
 }
 
-const EASTER_EGG_SOURCE = `// Create a fairly even lattice using the generators
+const EASTER_EGG_SOURCE = `(* Create a fairly even lattice using the generators *)
 parallelotope([3, 5, 7], [1, 1, 1], [0, 0, 1], 1\\6)
-// Temper out the Spoob comma
+(* Temper out the Spoob comma *)
 PrimeMapping(1200.000, 1901.955, 2786.316, 3368.819, 4151.323)
 `
 


### PR DESCRIPTION
SonicWeave changelog
- Replace C-style comments with nestable OCaml-style comments
- Implement popped scale magic syntax `£` (ASCII `pop$`) and `££` (ASCII `pop$$`)
- Tweak stdlib semantics to remove past tense verbs: E.g. `sort()` pops the scale and returns a sorted copy.