### PR TITLE
Update sonic-weave dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "moment-of-symmetry": "^0.8.4",
         "pinia": "^2.3.0",
         "qs": "^6.13.1",
-        "sonic-weave": "^0.10.9",
+        "sonic-weave": "^0.10.10",
         "sw-synth": "^0.1.2",
         "values.js": "^2.1.1",
         "vue": "^3.3.4",
@@ -5446,9 +5446,9 @@
       }
     },
     "node_modules/sonic-weave": {
-      "version": "0.10.9",
-      "resolved": "https://registry.npmjs.org/sonic-weave/-/sonic-weave-0.10.9.tgz",
-      "integrity": "sha512-pGBOrN4RiEpaBhiOUJU/GzKH/dcMabEvPdu4l9Q+gcOGaVY0JIOZB07CKRVBHcnV9ZNJT9vDBqpFvDnxgDtKFw==",
+      "version": "0.10.10",
+      "resolved": "https://registry.npmjs.org/sonic-weave/-/sonic-weave-0.10.10.tgz",
+      "integrity": "sha512-dM1HgaXpuz3aSu1N2KtsEUaDEaE87O69b1liXYrbaeLc2YEYZjbcARM0Nv08GP4Z2V7C/jmXYoLu3Pyw+dTEfw==",
       "dependencies": {
         "moment-of-symmetry": "^0.8.4",
         "xen-dev-utils": "^0.11.1"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "moment-of-symmetry": "^0.8.4",
     "pinia": "^2.3.0",
     "qs": "^6.13.1",
-    "sonic-weave": "^0.10.9",
+    "sonic-weave": "^0.10.10",
     "sw-synth": "^0.1.2",
     "values.js": "^2.1.1",
     "vue": "^3.3.4",


### PR DESCRIPTION
SonicWeave changelog:
* Implement the missing size inequality operator `~<>` (i.e. the negation of `~=`).
* Fix domain error in `realizeWord`.
* Fix typos in error messages.
* Accept lone vals for `commaBasis` and `mappingBasis`.
* Admit containers as spread arguments

ref #823