### PR TITLE
Move input handling to the parent virtual keyboard element

### DIFF
--- a/src/components/VirtualKeyboard.vue
+++ b/src/components/VirtualKeyboard.vue
@@ -29,6 +29,7 @@ const props = defineProps<{
 type VirtualKey = {
   x: number
   y: number
+  id: string
   index: number
   color: string
   frequency: number
@@ -53,6 +54,7 @@ const virtualKeys = computed(() => {
       row.push({
         x,
         y,
+        id: `${x},${y}`,
         index,
         color,
         frequency,
@@ -67,65 +69,65 @@ const virtualKeys = computed(() => {
 })
 
 const isMousePressed = ref(false)
-const noteOffs: Map<number, NoteOff> = new Map()
+const noteOffs: Map<string, NoteOff> = new Map()
 
-function start(index: number) {
-  end(index)
-  noteOffs.set(index, props.noteOn(index))
+function start(key: VirtualKey) {
+  end(key)
+  noteOffs.set(key.id, props.noteOn(key.index))
 }
 
-function end(index: number) {
-  if (noteOffs.has(index)) {
-    noteOffs.get(index)!()
-    noteOffs.delete(index)
+function end(key: VirtualKey) {
+  if (noteOffs.has(key.id)) {
+    noteOffs.get(key.id)!()
+    noteOffs.delete(key.id)
   }
 }
 
-function isActive(index: number) {
-  return noteOffs.has(index)
+function isActive(key: VirtualKey) {
+  return noteOffs.has(key.id)
 }
 
-function onTouchStart(event: TouchEvent, index: number) {
+function onTouchStart(event: TouchEvent, key: VirtualKey) {
   event.preventDefault()
-  start(index)
+  start(key)
 }
 
-function onTouchEnd(event: TouchEvent, index: number) {
+function onTouchEnd(event: TouchEvent, key: VirtualKey) {
   event.preventDefault()
-  end(index)
+  end(key)
 }
 
-function onMouseDown(event: MouseEvent, index: number) {
+function onMouseDown(event: MouseEvent, key: VirtualKey) {
   if (event.button !== LEFT_MOUSE_BTN) {
     return
   }
   event.preventDefault()
   isMousePressed.value = true
-  start(index)
+  start(key)
 }
 
-function onMouseUp(event: MouseEvent, index: number) {
+function onMouseUp(event: MouseEvent, key: VirtualKey) {
   if (event.button !== LEFT_MOUSE_BTN) {
     return
   }
   event.preventDefault()
-  end(index)
+  end(key)
 }
 
-function onMouseEnter(event: MouseEvent, index: number) {
+function onMouseEnter(event: MouseEvent, key: VirtualKey) {
   if (!isMousePressed.value) {
     return
   }
   event.preventDefault()
-  start(index)
+  start(key)
 }
 
-function onMouseLeave(event: MouseEvent, index: number) {
+function onMouseLeave(event: MouseEvent, key: VirtualKey) {
   if (!isMousePressed.value) {
     return
   }
   event.preventDefault()
-  end(index)
+  end(key)
 }
 
 function windowMouseUp(event: MouseEvent) {
@@ -153,19 +155,19 @@ onUnmounted(() => {
       <tr v-for="[y, row] of virtualKeys" :key="y" :class="{ 'hidden-sm': y < 0 || y > 3 }">
         <VirtualKeyboardKey
           v-for="key of row"
-          :key="key.x"
+          :key="key.id"
           :class="{ 'hidden-sm': key.x > 8 }"
           :index="key.index"
           :color="key.color"
-          :active="isActive(key.index)"
+          :active="isActive(key)"
           :held="(heldNotes.get(key.index) || 0) > 0"
-          @touchstart="onTouchStart($event, key.index)"
-          @touchend="onTouchEnd($event, key.index)"
-          @touchcancel="onTouchEnd($event, key.index)"
-          @mousedown="onMouseDown($event, key.index)"
-          @mouseup="onMouseUp($event, key.index)"
-          @mouseenter="onMouseEnter($event, key.index)"
-          @mouseleave="onMouseLeave($event, key.index)"
+          @touchstart="onTouchStart($event, key)"
+          @touchend="onTouchEnd($event, key)"
+          @touchcancel="onTouchEnd($event, key)"
+          @mousedown="onMouseDown($event, key)"
+          @mouseup="onMouseUp($event, key)"
+          @mouseenter="onMouseEnter($event, key)"
+          @mouseleave="onMouseLeave($event, key)"
         >
           <VirtualKeyInfo
             :label="key.label"

--- a/src/components/VirtualKeyboard.vue
+++ b/src/components/VirtualKeyboard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { LEFT_MOUSE_BTN } from '@/constants'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
 import VirtualKeyboardKey from '@/components/VirtualKeyboardKey.vue'
 import VirtualKeyInfo from '@/components/VirtualKeyInfo.vue'
 import type { Scale } from '@/scale'
@@ -66,6 +67,80 @@ const virtualKeys = computed(() => {
 })
 
 const isMousePressed = ref(false)
+const noteOffs: Map<number, NoteOff> = new Map()
+
+function start(index: number) {
+  end(index)
+  noteOffs.set(index, props.noteOn(index))
+}
+
+function end(index: number) {
+  if (noteOffs.has(index)) {
+    noteOffs.get(index)!()
+    noteOffs.delete(index)
+  }
+}
+
+function onTouchStart(event: TouchEvent, index: number) {
+  event.preventDefault()
+  start(index)
+}
+
+function onTouchEnd(event: TouchEvent, index: number) {
+  event.preventDefault()
+  end(index)
+}
+
+function onMouseDown(event: MouseEvent, index: number) {
+  if (event.button !== LEFT_MOUSE_BTN) {
+    return
+  }
+  event.preventDefault()
+  isMousePressed.value = true
+  start(index)
+}
+
+function onMouseUp(event: MouseEvent, index: number) {
+  if (event.button !== LEFT_MOUSE_BTN) {
+    return
+  }
+  event.preventDefault()
+  end(index)
+}
+
+function onMouseEnter(event: MouseEvent, index: number) {
+  if (!isMousePressed.value) {
+    return
+  }
+  event.preventDefault()
+  start(index)
+}
+
+function onMouseLeave(event: MouseEvent, index: number) {
+  if (!isMousePressed.value) {
+    return
+  }
+  event.preventDefault()
+  end(index)
+}
+
+function windowMouseUp(event: MouseEvent) {
+  if (event.button !== LEFT_MOUSE_BTN) {
+    return
+  }
+  isMousePressed.value = false
+  noteOffs.forEach((off) => off())
+  noteOffs.clear()
+}
+
+onMounted(() => {
+  window.addEventListener('mouseup', windowMouseUp)
+})
+
+onUnmounted(() => {
+  noteOffs.forEach((off) => off())
+  window.removeEventListener('mouseup', windowMouseUp)
+})
 </script>
 
 <template>
@@ -81,10 +156,13 @@ const isMousePressed = ref(false)
           }"
           :index="key.index"
           :color="key.color"
-          :isMousePressed="isMousePressed"
-          :noteOn="() => noteOn(key.index)"
-          @press="isMousePressed = true"
-          @unpress="isMousePressed = false"
+          :active="(heldNotes.get(key.index) || 0) > 0"
+          @touchstart="onTouchStart($event, key.index)"
+          @touchend="onTouchEnd($event, key.index)"
+          @mousedown="onMouseDown($event, key.index)"
+          @mouseup="onMouseUp($event, key.index)"
+          @mouseenter="onMouseEnter($event, key.index)"
+          @mouseleave="onMouseLeave($event, key.index)"
         >
           <VirtualKeyInfo
             :label="key.label"

--- a/src/components/VirtualKeyboard.vue
+++ b/src/components/VirtualKeyboard.vue
@@ -81,6 +81,10 @@ function end(index: number) {
   }
 }
 
+function isActive(index: number) {
+  return noteOffs.has(index)
+}
+
 function onTouchStart(event: TouchEvent, index: number) {
   event.preventDefault()
   start(index)
@@ -156,9 +160,10 @@ onUnmounted(() => {
           }"
           :index="key.index"
           :color="key.color"
-          :active="(heldNotes.get(key.index) || 0) > 0"
+          :active="isActive(key.index)"
           @touchstart="onTouchStart($event, key.index)"
           @touchend="onTouchEnd($event, key.index)"
+          @touchcancel="onTouchEnd($event, key.index)"
           @mousedown="onMouseDown($event, key.index)"
           @mouseup="onMouseUp($event, key.index)"
           @mouseenter="onMouseEnter($event, key.index)"

--- a/src/components/VirtualKeyboard.vue
+++ b/src/components/VirtualKeyboard.vue
@@ -154,13 +154,11 @@ onUnmounted(() => {
         <VirtualKeyboardKey
           v-for="key of row"
           :key="key.x"
-          :class="{
-            'hidden-sm': key.x > 8,
-            held: (heldNotes.get(key.index) || 0) > 0
-          }"
+          :class="{ 'hidden-sm': key.x > 8 }"
           :index="key.index"
           :color="key.color"
           :active="isActive(key.index)"
+          :held="(heldNotes.get(key.index) || 0) > 0"
           @touchstart="onTouchStart($event, key.index)"
           @touchend="onTouchEnd($event, key.index)"
           @touchcancel="onTouchEnd($event, key.index)"

--- a/src/components/VirtualKeyboardKey.vue
+++ b/src/components/VirtualKeyboardKey.vue
@@ -9,8 +9,6 @@ const props = defineProps<{
 }>()
 
 const light = computed(() => new Values(props.color).getBrightness() > 50)
-
-defineEmits(['touchstart', 'touchend', 'mousedown', 'mouseup', 'mouseenter', 'mouseleave'])
 </script>
 
 <template>
@@ -18,13 +16,6 @@ defineEmits(['touchstart', 'touchend', 'mousedown', 'mouseup', 'mouseenter', 'mo
     :data-key-number="index"
     :style="'background-color:' + color"
     :class="{ active, light, dark: !light }"
-    @touchstart="$emit('touchstart', $event)"
-    @touchend="$emit('touchend', $event)"
-    @touchcancel="$emit('touchend', $event)"
-    @mousedown="$emit('mousedown', $event)"
-    @mouseup="$emit('mouseup', $event)"
-    @mouseenter="$emit('mouseenter', $event)"
-    @mouseleave="$emit('mouseleave', $event)"
   >
     <slot></slot>
   </td>

--- a/src/components/VirtualKeyboardKey.vue
+++ b/src/components/VirtualKeyboardKey.vue
@@ -6,6 +6,7 @@ const props = defineProps<{
   index: number
   color: string
   active: boolean
+  held: boolean
 }>()
 
 const light = computed(() => new Values(props.color).getBrightness() > 50)
@@ -15,7 +16,7 @@ const light = computed(() => new Values(props.color).getBrightness() > 50)
   <td
     :data-key-number="index"
     :style="'background-color:' + color"
-    :class="{ active, light, dark: !light }"
+    :class="{ active, held, light, dark: !light }"
   >
     <slot></slot>
   </td>

--- a/src/components/VirtualKeyboardKey.vue
+++ b/src/components/VirtualKeyboardKey.vue
@@ -1,102 +1,16 @@
 <script setup lang="ts">
-import { LEFT_MOUSE_BTN } from '@/constants'
-import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { computed } from 'vue'
 import Values from 'values.js'
-
-type NoteOff = () => void
-type NoteOnCallback = () => NoteOff
 
 const props = defineProps<{
   index: number
   color: string
-  isMousePressed: boolean
-  noteOn: NoteOnCallback
+  active: boolean
 }>()
-
-const active = ref(false)
 
 const light = computed(() => new Values(props.color).getBrightness() > 50)
 
-const emit = defineEmits(['press', 'unpress'])
-
-let noteOff: NoteOff | null = null
-
-function start() {
-  active.value = true
-  if (noteOff !== null) {
-    noteOff()
-  }
-  noteOff = props.noteOn()
-}
-
-function end() {
-  active.value = false
-  if (noteOff !== null) {
-    noteOff()
-    noteOff = null
-  }
-}
-
-function onTouchStart(event: TouchEvent) {
-  event.preventDefault()
-  start()
-}
-
-function onTouchEnd(event: TouchEvent) {
-  event.preventDefault()
-  end()
-}
-
-function onMouseDown(event: MouseEvent) {
-  if (event.button !== LEFT_MOUSE_BTN) {
-    return
-  }
-  event.preventDefault()
-  emit('press')
-  start()
-}
-
-function onMouseUp(event: MouseEvent) {
-  if (event.button !== LEFT_MOUSE_BTN) {
-    return
-  }
-  event.preventDefault()
-}
-
-function onWindowMouseUp(event: MouseEvent) {
-  if (event.button !== LEFT_MOUSE_BTN) {
-    return
-  }
-  emit('unpress')
-  end()
-}
-
-function onMouseEnter(event: MouseEvent) {
-  if (!props.isMousePressed) {
-    return
-  }
-  event.preventDefault()
-  start()
-}
-
-function onMouseLeave(event: MouseEvent) {
-  if (!props.isMousePressed) {
-    return
-  }
-  event.preventDefault()
-  end()
-}
-
-onMounted(() => {
-  window.addEventListener('mouseup', onWindowMouseUp)
-})
-
-onUnmounted(() => {
-  if (noteOff !== null) {
-    noteOff()
-  }
-  window.removeEventListener('mouseup', onWindowMouseUp)
-})
+defineEmits(['touchstart', 'touchend', 'mousedown', 'mouseup', 'mouseenter', 'mouseleave'])
 </script>
 
 <template>
@@ -104,13 +18,13 @@ onUnmounted(() => {
     :data-key-number="index"
     :style="'background-color:' + color"
     :class="{ active, light, dark: !light }"
-    @touchstart="onTouchStart"
-    @touchend="onTouchEnd"
-    @touchcancel="onTouchEnd"
-    @mousedown="onMouseDown"
-    @mouseup="onMouseUp"
-    @mouseenter="onMouseEnter"
-    @mouseleave="onMouseLeave"
+    @touchstart="$emit('touchstart', $event)"
+    @touchend="$emit('touchend', $event)"
+    @touchcancel="$emit('touchend', $event)"
+    @mousedown="$emit('mousedown', $event)"
+    @mouseup="$emit('mouseup', $event)"
+    @mouseenter="$emit('mouseenter', $event)"
+    @mouseleave="$emit('mouseleave', $event)"
   >
     <slot></slot>
   </td>


### PR DESCRIPTION
Clears up multiple emitted 'unpress' events and unifies logic with VirtualPiano.vue.