### PR TITLE
Add similar scales analysis tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "scale-workshop",
       "version": "3.4.0",
       "dependencies": {
+        "@narenratan/scale-library": "1.3.0",
         "harmonic-entropy": "^0.3.1",
         "isomorphic-qwerty": "^0.1.1",
         "ji-lattice": "^0.3.2",
@@ -1652,6 +1653,11 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@narenratan/scale-library": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@narenratan/scale-library/-/scale-library-1.3.0.tgz",
+      "integrity": "sha512-LqhzyjF4J9wXKnUwuWTtWn7CuSmKePPrWbPR+w2TbD9Kr330ahr80A6LJ0iEpKO93HV20uuMPar+zwLk9ilVyw=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "format": "prettier --write --experimental-cli src/"
   },
   "dependencies": {
+    "@narenratan/scale-library": "1.3.0",
     "harmonic-entropy": "^0.3.1",
     "isomorphic-qwerty": "^0.1.1",
     "ji-lattice": "^0.3.2",

--- a/src/__tests__/similar-scales.spec.ts
+++ b/src/__tests__/similar-scales.spec.ts
@@ -39,17 +39,17 @@ describe('Minimum mode distance', () => {
 })
 
 describe('Maximum nearest-note distance', () => {
-  it('finds zero distance for a child which is a subset of the parent', () => {
-    const parent = [200.0, 400.0, 500.0, 700.0, 900.0, 1100.0]
-    const child = [200.0, 400.0, 700.0, 900.0]
-    const dist = maxNearestDistance(parent, child, 1200.0, 1200.0)
+  it('finds zero distance for a parent which is a subset of the child', () => {
+    const child = [200.0, 400.0, 500.0, 700.0, 900.0, 1100.0]
+    const parent = [200.0, 400.0, 700.0, 900.0]
+    const dist = maxNearestDistance(child, parent, 1200.0, 1200.0)
     expect(dist).toBeCloseTo(0)
   })
 
-  it('finds distance 15.6 for tempered major pentatonic as child of just major scale', () => {
-    const parent = [203.9, 386.3, 498.0, 702.0, 884.4, 1088.3]
-    const child = [200.0, 400.0, 700.0, 900.0]
-    const dist = maxNearestDistance(parent, child, 1200.0, 1200.0)
+  it('finds distance 15.6 for tempered major pentatonic as parent of just major scale', () => {
+    const child = [203.9, 386.3, 498.0, 702.0, 884.4, 1088.3]
+    const parent = [200.0, 400.0, 700.0, 900.0]
+    const dist = maxNearestDistance(child, parent, 1200.0, 1200.0)
     expect(dist).toBeCloseTo(15.6)
   })
 
@@ -60,9 +60,9 @@ describe('Maximum nearest-note distance', () => {
   })
 
   it('accounts for differences in period in dist, for different sized scales', () => {
-    const parent = [200.0, 400.0, 500.0, 700.0, 900.0, 1100.0]
-    const child = [200.0, 400.0, 700.0, 900.0]
-    const dist = maxNearestDistance(parent, child, 1200.0, 1190.0)
+    const child = [200.0, 400.0, 500.0, 700.0, 900.0, 1100.0]
+    const parent = [200.0, 400.0, 700.0, 900.0]
+    const dist = maxNearestDistance(child, parent, 1200.0, 1190.0)
     expect(dist).toBeCloseTo(10.0)
   })
 
@@ -99,7 +99,7 @@ describe('Canonical mode key', () => {
 })
 
 describe('Similar scales computation', () => {
-  it('finds one similar scale, parent, and child when expected', () => {
+  it('finds one similar scale, child, and parent when expected', () => {
     const queryCents = [200.0, 400.0, 500.0, 700.0, 900.0, 1100.0]
     const library = [
       { stem: 'just-major-pentatonic', cents: [203.9, 386.3, 702.0, 884.4], period: 1200.0 },
@@ -117,12 +117,12 @@ describe('Similar scales computation', () => {
     ]
     const result = computeSimilarScales(queryCents, 1200.0, library)
     expect(result.similar).toHaveLength(1)
-    expect(result.parents).toHaveLength(1)
     expect(result.children).toHaveLength(1)
+    expect(result.parents).toHaveLength(1)
 
     expect(result.similar[0].stem).toBe('just-major')
-    expect(result.parents[0].stem).toBe('12tet')
-    expect(result.children[0].stem).toBe('just-major-pentatonic')
+    expect(result.children[0].stem).toBe('12tet')
+    expect(result.parents[0].stem).toBe('just-major-pentatonic')
   })
 
   it('deduplicates modes when looking for similar scales', () => {
@@ -133,7 +133,7 @@ describe('Similar scales computation', () => {
     ]
     const result = computeSimilarScales(queryCents, 1200.0, library)
     expect(result.similar).toHaveLength(1)
-    expect(result.parents).toHaveLength(0)
     expect(result.children).toHaveLength(0)
+    expect(result.parents).toHaveLength(0)
   })
 })

--- a/src/__tests__/similar-scales.spec.ts
+++ b/src/__tests__/similar-scales.spec.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest'
+import {
+  minModeDistance,
+  maxNearestDistance,
+  canonicalModeKey,
+  computeSimilarScales
+} from '../similar-scales'
+
+describe('Minimum mode distance', () => {
+  it('finds dist 15.6, mode 0 for just vs equal tempered major scale', () => {
+    const a = [203.9, 386.3, 498.0, 702.0, 884.4, 1088.3]
+    const b = [200.0, 400.0, 500.0, 700.0, 900.0, 1100.0]
+    const { dist, mode } = minModeDistance(a, b, 1200.0, 1200.0)
+    expect(dist).toBeCloseTo(15.6)
+    expect(mode).toBe(0)
+  })
+
+  it('finds dist 15.6, mode 1 for just major pentatonic vs equal tempered minor pentatonic', () => {
+    const a = [203.9, 386.3, 702.0, 884.4]
+    const b = [300.0, 500.0, 700.0, 1000.0]
+    const { dist, mode } = minModeDistance(a, b, 1200.0, 1200.0)
+    expect(dist).toBeCloseTo(15.6)
+    expect(mode).toBe(1)
+  })
+
+  it('accounts for differences in period in dist', () => {
+    const a = [200.0, 400.0, 700.0, 900.0]
+    const { dist, mode } = minModeDistance(a, a, 1200.0, 1190.0)
+    expect(dist).toBeCloseTo(10.0)
+    expect(mode).toBe(0)
+  })
+
+  it('finds zero distance for identical scales', () => {
+    const a = [200.0, 400.0, 700.0, 1000.0]
+    const { dist, mode } = minModeDistance(a, a, 1200.0, 1200.0)
+    expect(dist).toBeCloseTo(0)
+    expect(mode).toBe(0)
+  })
+})
+
+describe('Maximum nearest-note distance', () => {
+  it('finds zero distance for a child which is a subset of the parent', () => {
+    const parent = [200.0, 400.0, 500.0, 700.0, 900.0, 1100.0]
+    const child = [200.0, 400.0, 700.0, 900.0]
+    const dist = maxNearestDistance(parent, child, 1200.0, 1200.0)
+    expect(dist).toBeCloseTo(0)
+  })
+
+  it('finds distance 15.6 for tempered major pentatonic as child of just major scale', () => {
+    const parent = [203.9, 386.3, 498.0, 702.0, 884.4, 1088.3]
+    const child = [200.0, 400.0, 700.0, 900.0]
+    const dist = maxNearestDistance(parent, child, 1200.0, 1200.0)
+    expect(dist).toBeCloseTo(15.6)
+  })
+
+  it('accounts for differences in period in dist', () => {
+    const a = [200.0, 400.0, 700.0, 900.0]
+    const dist = maxNearestDistance(a, a, 1200.0, 1190.0)
+    expect(dist).toBeCloseTo(10.0)
+  })
+
+  it('accounts for differences in period in dist, for different sized scales', () => {
+    const parent = [200.0, 400.0, 500.0, 700.0, 900.0, 1100.0]
+    const child = [200.0, 400.0, 700.0, 900.0]
+    const dist = maxNearestDistance(parent, child, 1200.0, 1190.0)
+    expect(dist).toBeCloseTo(10.0)
+  })
+
+  it('finds zero distance for identical scales', () => {
+    const a = [200.0, 400.0, 700.0, 1000.0]
+    const dist = maxNearestDistance(a, a, 1200.0, 1200.0)
+    expect(dist).toBeCloseTo(0)
+  })
+})
+
+describe('Canonical mode key', () => {
+  it('gives the same key for scales which are modes of each other', () => {
+    const a = [200.0, 400.0, 700.0, 900.0] // major pentatonic
+    const b = [300.0, 500.0, 700.0, 1000.0] // minor pentatonic
+    const keyA = canonicalModeKey(a, 1200.0)
+    const keyB = canonicalModeKey(b, 1200.0)
+    expect(keyA).toBe(keyB)
+  })
+
+  it('gives different keys to scales which are not modes of each other', () => {
+    const a = [250.0, 400.0, 700.0, 900.0]
+    const b = [300.0, 500.0, 700.0, 1000.0]
+    const keyA = canonicalModeKey(a, 1200.0)
+    const keyB = canonicalModeKey(b, 1200.0)
+    expect(keyA).not.toBe(keyB)
+  })
+
+  it('gives different keys to scales which differ only in period', () => {
+    const a = [200.0, 400.0, 700.0, 900.0]
+    const keyA = canonicalModeKey(a, 1200.0)
+    const keyB = canonicalModeKey(a, 1190.0)
+    expect(keyA).not.toBe(keyB)
+  })
+})
+
+describe('Similar scales computation', () => {
+  it('finds one similar scale, parent, and child when expected', () => {
+    const queryCents = [200.0, 400.0, 500.0, 700.0, 900.0, 1100.0]
+    const library = [
+      { stem: 'just-major-pentatonic', cents: [203.9, 386.3, 702.0, 884.4], period: 1200.0 },
+      { stem: 'just-major', cents: [203.9, 386.3, 498.0, 702.0, 884.4, 1088.3], period: 1200.0 },
+      {
+        stem: '12tet',
+        cents: [100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0, 900.0, 1000.0, 1100.0],
+        period: 1200.0
+      },
+      {
+        stem: 'non-matching-scale',
+        cents: [200.0, 350.0, 500.0, 700.0, 900.0, 1100.0],
+        period: 1200.0
+      }
+    ]
+    const result = computeSimilarScales(queryCents, 1200.0, library)
+    expect(result.similar).toHaveLength(1)
+    expect(result.parents).toHaveLength(1)
+    expect(result.children).toHaveLength(1)
+
+    expect(result.similar[0].stem).toBe('just-major')
+    expect(result.parents[0].stem).toBe('12tet')
+    expect(result.children[0].stem).toBe('just-major-pentatonic')
+  })
+
+  it('deduplicates modes when looking for similar scales', () => {
+    const queryCents = [203.9, 386.3, 702.0, 884.4]
+    const library = [
+      { stem: 'major-pentatonic', cents: [200.0, 400.0, 700.0, 900.0], period: 1200.0 },
+      { stem: 'minor-pentatonic', cents: [300.0, 500.0, 700.0, 1000.0], period: 1200.0 }
+    ]
+    const result = computeSimilarScales(queryCents, 1200.0, library)
+    expect(result.similar).toHaveLength(1)
+    expect(result.parents).toHaveLength(0)
+    expect(result.children).toHaveLength(0)
+  })
+})

--- a/src/similar-scales.ts
+++ b/src/similar-scales.ts
@@ -1,7 +1,7 @@
 const CENTS_TOL = 25.0
 const SIMILAR_CAP = 10
-const MIN_CHILD_NOTES = 4
-const PARENT_SIZE_K = 10.0 / Math.log(2) // cents cost per doubling of parent size
+const MIN_PARENT_NOTES = 4
+const CHILD_SIZE_K = 10.0 / Math.log(2) // cents cost per doubling of child size
 
 export interface LibraryScale {
   stem: string
@@ -20,8 +20,8 @@ type ParentChildEntry = Omit<SimilarEntry, 'mode'>
 
 export interface SimilarResult {
   similar: SimilarEntry[]
-  parents: ParentChildEntry[]
   children: ParentChildEntry[]
+  parents: ParentChildEntry[]
 }
 
 function round1(x: number): number {
@@ -110,30 +110,31 @@ export function minModeDistance(
 }
 
 /**
- * Compute the error of the closest approximation of a child scale within a parent scale.
- * @param parentCents Cents of parent scale, excluding 0.0 and period.
+ * Compute the error of the closest approximation of a parent scale within a child scale.
+ * The parent is the smaller scale, the child is the larger scale.
  * @param childCents Cents of child scale, excluding 0.0 and period.
- * @param parentPeriod Period of parent scale, in cents.
+ * @param parentCents Cents of parent scale, excluding 0.0 and period.
  * @param childPeriod Period of child scale, in cents.
- * @returns The max abs cents diff between the child and its closest approximation in the parent.
+ * @param parentPeriod Period of parent scale, in cents.
+ * @returns The max abs cents diff between the parent and its closest approximation in the child.
  */
 export function maxNearestDistance(
-  parentCents: number[],
   childCents: number[],
-  parentPeriod: number,
-  childPeriod: number
+  parentCents: number[],
+  childPeriod: number,
+  parentPeriod: number
 ): number {
-  const fullParent = [0, ...parentCents, parentPeriod]
+  const fullChild = [0, ...childCents, childPeriod]
   let maxDist = 0
-  for (const childNote of childCents) {
+  for (const parentNote of parentCents) {
     let minDiff = Infinity
-    for (const parentNote of fullParent) {
-      const diff = Math.abs(childNote - parentNote)
+    for (const childNote of fullChild) {
+      const diff = Math.abs(parentNote - childNote)
       if (diff < minDiff) minDiff = diff
     }
     if (minDiff > maxDist) maxDist = minDiff
   }
-  return Math.max(maxDist, Math.abs(parentPeriod - childPeriod))
+  return Math.max(maxDist, Math.abs(childPeriod - parentPeriod))
 }
 
 /**
@@ -166,11 +167,11 @@ function dedupByModalClass(
 }
 
 /**
- * Compute similar, parent, and child scales for a given user scale.
+ * Compute similar, child, and parent scales for a given user scale.
  * @param queryCents Cents of user scale, excluding 0.0 and period.
  * @param queryPeriod Period of user scale, in cents.
  * @param library Library of scales to search for similar scales.
- * @returns Arrays of similar, parent, and child scales and their fitting data.
+ * @returns Arrays of similar, child, and parent scales and their fitting data.
  */
 export function computeSimilarScales(
   queryCents: number[],
@@ -208,45 +209,20 @@ export function computeSimilarScales(
     return { similar, parents: [], children: [] }
   }
 
-  // --- Parents ---
-  const parents: ParentChildEntry[] = []
-  const parentCandidates: Array<{ scale: LibraryScale; dist: number }> = []
-  for (const libScale of library) {
-    if (libScale.cents.length <= queryNotes) continue
-    const dist = maxNearestDistance(libScale.cents, queryCents, libScale.period, queryPeriod)
-    if (dist <= CENTS_TOL) {
-      parentCandidates.push({ scale: libScale, dist })
-    }
-  }
-  parentCandidates.sort((a, b) => {
-    const scoreA = a.dist + PARENT_SIZE_K * Math.log(a.scale.cents.length / queryNotes)
-    const scoreB = b.dist + PARENT_SIZE_K * Math.log(b.scale.cents.length / queryNotes)
-    if (scoreA !== scoreB) return scoreA - scoreB
-    return stemBasename(a.scale.stem).localeCompare(stemBasename(b.scale.stem))
-  })
-  for (const { scale, dist } of parentCandidates.slice(0, SIMILAR_CAP)) {
-    parents.push({
-      stem: scale.stem,
-      notes: scale.cents.length + 1,
-      maxDiff: round1(dist)
-    })
-  }
-
   // --- Children ---
   const children: ParentChildEntry[] = []
   const childCandidates: Array<{ scale: LibraryScale; dist: number }> = []
   for (const libScale of library) {
-    if (libScale.cents.length >= queryNotes) continue
-    if (libScale.cents.length < MIN_CHILD_NOTES) continue
-    const dist = maxNearestDistance(queryCents, libScale.cents, queryPeriod, libScale.period)
+    if (libScale.cents.length <= queryNotes) continue
+    const dist = maxNearestDistance(libScale.cents, queryCents, libScale.period, queryPeriod)
     if (dist <= CENTS_TOL) {
       childCandidates.push({ scale: libScale, dist })
     }
   }
   childCandidates.sort((a, b) => {
-    if (a.dist !== b.dist) return a.dist - b.dist
-    const nDiff = b.scale.cents.length - a.scale.cents.length // largest first
-    if (nDiff !== 0) return nDiff
+    const scoreA = a.dist + CHILD_SIZE_K * Math.log(a.scale.cents.length / queryNotes)
+    const scoreB = b.dist + CHILD_SIZE_K * Math.log(b.scale.cents.length / queryNotes)
+    if (scoreA !== scoreB) return scoreA - scoreB
     return stemBasename(a.scale.stem).localeCompare(stemBasename(b.scale.stem))
   })
   for (const { scale, dist } of childCandidates.slice(0, SIMILAR_CAP)) {
@@ -257,5 +233,30 @@ export function computeSimilarScales(
     })
   }
 
-  return { similar, parents, children }
+  // --- Parents ---
+  const parents: ParentChildEntry[] = []
+  const parentCandidates: Array<{ scale: LibraryScale; dist: number }> = []
+  for (const libScale of library) {
+    if (libScale.cents.length >= queryNotes) continue
+    if (libScale.cents.length < MIN_PARENT_NOTES) continue
+    const dist = maxNearestDistance(queryCents, libScale.cents, queryPeriod, libScale.period)
+    if (dist <= CENTS_TOL) {
+      parentCandidates.push({ scale: libScale, dist })
+    }
+  }
+  parentCandidates.sort((a, b) => {
+    if (a.dist !== b.dist) return a.dist - b.dist
+    const nDiff = b.scale.cents.length - a.scale.cents.length // largest first
+    if (nDiff !== 0) return nDiff
+    return stemBasename(a.scale.stem).localeCompare(stemBasename(b.scale.stem))
+  })
+  for (const { scale, dist } of parentCandidates.slice(0, SIMILAR_CAP)) {
+    parents.push({
+      stem: scale.stem,
+      notes: scale.cents.length + 1,
+      maxDiff: round1(dist)
+    })
+  }
+
+  return { similar, children, parents }
 }

--- a/src/similar-scales.ts
+++ b/src/similar-scales.ts
@@ -1,0 +1,261 @@
+const CENTS_TOL = 25.0
+const SIMILAR_CAP = 10
+const MIN_CHILD_NOTES = 4
+const PARENT_SIZE_K = 10.0 / Math.log(2) // cents cost per doubling of parent size
+
+export interface LibraryScale {
+  stem: string
+  cents: number[] // sorted, period excluded
+  period: number
+}
+
+interface SimilarEntry {
+  stem: string
+  notes: number
+  maxDiff: number
+  mode: number
+}
+
+type ParentChildEntry = Omit<SimilarEntry, 'mode'>
+
+export interface SimilarResult {
+  similar: SimilarEntry[]
+  parents: ParentChildEntry[]
+  children: ParentChildEntry[]
+}
+
+function round1(x: number): number {
+  return Math.round(x * 10) / 10
+}
+
+function round4(x: number): number {
+  return Math.round(x * 10000) / 10000
+}
+
+function compareNumberArrays(a: number[], b: number[]): number {
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return a[i] - b[i]
+  }
+  return 0
+}
+
+/**
+ * Calculate a string to identify scales which are modes of each other.
+ */
+export function canonicalModeKey(cents: number[], period: number): string {
+  if (cents.length === 0) {
+    return JSON.stringify([round4(period)])
+  }
+  const full = [0, ...cents, period]
+  const steps: number[] = []
+  for (let i = 1; i < full.length; i++) {
+    steps.push(round4(full[i] - full[i - 1]))
+  }
+  const n = steps.length
+  let maxRotation = steps
+  for (let i = 1; i < n; i++) {
+    const rotation = [...steps.slice(i), ...steps.slice(0, i)]
+    if (compareNumberArrays(rotation, maxRotation) > 0) {
+      maxRotation = rotation
+    }
+  }
+  return JSON.stringify(maxRotation)
+}
+
+/**
+ * Find the minimum max-absolute-difference distance between scale a and any mode of scale b.
+ * @param a Cents of scale a, excluding 0.0 and period.
+ * @param b Cents of scale b, excluding 0.0 and period.
+ * @param periodA Period of scale a, in cents.
+ * @param periodB Period of scale b, in cents.
+ * @returns The minimum max-absolute cents difference over all rotations, and the index of the closest rotation.
+ */
+export function minModeDistance(
+  a: number[],
+  b: number[],
+  periodA: number,
+  periodB: number
+): { dist: number; mode: number } {
+  const n = a.length
+  if (n === 0) {
+    return { dist: Math.abs(periodA - periodB), mode: 0 }
+  }
+
+  // full_b includes the implicit root 0¢, giving n+1 possible rotation pivots
+  const fullB = [0, ...b]
+  let best = Infinity
+  let bestMode = 0
+
+  for (let r = 0; r <= n; r++) {
+    const pivot = fullB[r]
+    // Rotate: subtract pivot, mod periodB, sort
+    const rotFull = fullB
+      .map((x) => (((x - pivot) % periodB) + periodB) % periodB)
+      .sort((x, y) => x - y)
+    const rot = rotFull.slice(1) // exclude new root (0)
+    let maxDiff = 0
+    for (let i = 0; i < n; i++) {
+      const diff = Math.abs(a[i] - rot[i])
+      if (diff > maxDiff) maxDiff = diff
+    }
+    if (maxDiff < best) {
+      best = maxDiff
+      bestMode = r
+    }
+  }
+
+  // Period difference counts toward overall distance
+  const dist = Math.max(best, Math.abs(periodA - periodB))
+  return { dist, mode: bestMode }
+}
+
+/**
+ * Compute the error of the closest approximation of a child scale within a parent scale.
+ * @param parentCents Cents of parent scale, excluding 0.0 and period.
+ * @param childCents Cents of child scale, excluding 0.0 and period.
+ * @param parentPeriod Period of parent scale, in cents.
+ * @param childPeriod Period of child scale, in cents.
+ * @returns The max abs cents diff between the child and its closest approximation in the parent.
+ */
+export function maxNearestDistance(
+  parentCents: number[],
+  childCents: number[],
+  parentPeriod: number,
+  childPeriod: number
+): number {
+  const fullParent = [0, ...parentCents, parentPeriod]
+  let maxDist = 0
+  for (const childNote of childCents) {
+    let minDiff = Infinity
+    for (const parentNote of fullParent) {
+      const diff = Math.abs(childNote - parentNote)
+      if (diff < minDiff) minDiff = diff
+    }
+    if (minDiff > maxDist) maxDist = minDiff
+  }
+  return Math.max(maxDist, Math.abs(parentPeriod - childPeriod))
+}
+
+/**
+ * Find the base name of a library scale stem.
+ * For example, for xenharmonikon/xen03-secor-partch, return xen03-secor-partch.
+ */
+export function stemBasename(stem: string): string {
+  const parts = stem.split('/')
+  return parts[parts.length - 1]
+}
+
+/**
+ * Keep one representative per modal equivalence class, preferring the lowest rotation index.
+ * This is to avoid the similar scales table being filled with modes of the same scale.
+ * @param candidates Array of library scales, their distances, and mode numbers.
+ * @returns Deduplicated candidates, with at most one scale per modal equivalence class.
+ */
+function dedupByModalClass(
+  candidates: Array<{ scale: LibraryScale; dist: number; mode: number }>
+): Array<{ scale: LibraryScale; dist: number; mode: number }> {
+  const best = new Map<string, { scale: LibraryScale; dist: number; mode: number }>()
+  for (const item of candidates) {
+    const key = canonicalModeKey(item.scale.cents, item.scale.period)
+    const existing = best.get(key)
+    if (!existing || item.mode < existing.mode) {
+      best.set(key, item)
+    }
+  }
+  return Array.from(best.values())
+}
+
+/**
+ * Compute similar, parent, and child scales for a given user scale.
+ * @param queryCents Cents of user scale, excluding 0.0 and period.
+ * @param queryPeriod Period of user scale, in cents.
+ * @param library Library of scales to search for similar scales.
+ * @returns Arrays of similar, parent, and child scales and their fitting data.
+ */
+export function computeSimilarScales(
+  queryCents: number[],
+  queryPeriod: number,
+  library: LibraryScale[]
+): SimilarResult {
+  const queryNotes = queryCents.length
+
+  // --- Similar ---
+  const similarCandidates: Array<{ scale: LibraryScale; dist: number; mode: number }> = []
+  for (const libScale of library) {
+    if (libScale.cents.length !== queryNotes) continue
+    const { dist, mode } = minModeDistance(queryCents, libScale.cents, queryPeriod, libScale.period)
+    if (dist <= CENTS_TOL) {
+      similarCandidates.push({ scale: libScale, dist, mode })
+    }
+  }
+
+  const dedupedSimilar = dedupByModalClass(similarCandidates)
+  dedupedSimilar.sort((a, b) => {
+    if (a.dist !== b.dist) return a.dist - b.dist
+    return stemBasename(a.scale.stem).localeCompare(stemBasename(b.scale.stem))
+  })
+
+  const similar: SimilarEntry[] = dedupedSimilar
+    .slice(0, SIMILAR_CAP)
+    .map(({ scale, dist, mode }) => ({
+      stem: scale.stem,
+      notes: scale.cents.length + 1,
+      maxDiff: round1(dist),
+      mode
+    }))
+
+  if (queryNotes === 0) {
+    return { similar, parents: [], children: [] }
+  }
+
+  // --- Parents ---
+  const parents: ParentChildEntry[] = []
+  const parentCandidates: Array<{ scale: LibraryScale; dist: number }> = []
+  for (const libScale of library) {
+    if (libScale.cents.length <= queryNotes) continue
+    const dist = maxNearestDistance(libScale.cents, queryCents, libScale.period, queryPeriod)
+    if (dist <= CENTS_TOL) {
+      parentCandidates.push({ scale: libScale, dist })
+    }
+  }
+  parentCandidates.sort((a, b) => {
+    const scoreA = a.dist + PARENT_SIZE_K * Math.log(a.scale.cents.length / queryNotes)
+    const scoreB = b.dist + PARENT_SIZE_K * Math.log(b.scale.cents.length / queryNotes)
+    if (scoreA !== scoreB) return scoreA - scoreB
+    return stemBasename(a.scale.stem).localeCompare(stemBasename(b.scale.stem))
+  })
+  for (const { scale, dist } of parentCandidates.slice(0, SIMILAR_CAP)) {
+    parents.push({
+      stem: scale.stem,
+      notes: scale.cents.length + 1,
+      maxDiff: round1(dist)
+    })
+  }
+
+  // --- Children ---
+  const children: ParentChildEntry[] = []
+  const childCandidates: Array<{ scale: LibraryScale; dist: number }> = []
+  for (const libScale of library) {
+    if (libScale.cents.length >= queryNotes) continue
+    if (libScale.cents.length < MIN_CHILD_NOTES) continue
+    const dist = maxNearestDistance(queryCents, libScale.cents, queryPeriod, libScale.period)
+    if (dist <= CENTS_TOL) {
+      childCandidates.push({ scale: libScale, dist })
+    }
+  }
+  childCandidates.sort((a, b) => {
+    if (a.dist !== b.dist) return a.dist - b.dist
+    const nDiff = b.scale.cents.length - a.scale.cents.length // largest first
+    if (nDiff !== 0) return nDiff
+    return stemBasename(a.scale.stem).localeCompare(stemBasename(b.scale.stem))
+  })
+  for (const { scale, dist } of childCandidates.slice(0, SIMILAR_CAP)) {
+    children.push({
+      stem: scale.stem,
+      notes: scale.cents.length + 1,
+      maxDiff: round1(dist)
+    })
+  }
+
+  return { similar, parents, children }
+}

--- a/src/stores/similar.ts
+++ b/src/stores/similar.ts
@@ -2,8 +2,8 @@ import { ref } from 'vue'
 import { defineStore } from 'pinia'
 import { computeSimilarScales, type LibraryScale, type SimilarResult } from '@/similar-scales'
 
-export const SCALE_LIBRARY_BASE = 'https://scalelibrary.org'
-const SCALE_CENTS_URL = `${SCALE_LIBRARY_BASE}/scale-cents.json`
+const SCALE_CENTS_URL =
+  'https://cdn.jsdelivr.net/npm/@narenratan/scale-library@1.3.0/scale-cents.json'
 
 /**
  * Scale library cache and similar-scales computation store.

--- a/src/stores/similar.ts
+++ b/src/stores/similar.ts
@@ -1,0 +1,45 @@
+import { ref } from 'vue'
+import { defineStore } from 'pinia'
+import { computeSimilarScales, type LibraryScale, type SimilarResult } from '@/similar-scales'
+
+export const SCALE_LIBRARY_BASE = 'https://scalelibrary.org'
+const SCALE_CENTS_URL = `${SCALE_LIBRARY_BASE}/scale-cents.json`
+
+/**
+ * Scale library cache and similar-scales computation store.
+ */
+export const useSimilarStore = defineStore('similar', () => {
+  const library = ref<LibraryScale[]>([])
+  const isFetching = ref(false)
+  const fetchError = ref<string | null>(null)
+  const result = ref<SimilarResult | null>(null)
+
+  async function fetchLibrary() {
+    if (library.value.length || isFetching.value) return
+    isFetching.value = true
+    fetchError.value = null
+    try {
+      const response = await fetch(SCALE_CENTS_URL)
+      if (!response.ok) throw new Error(`HTTP ${response.status}`)
+      const raw: Record<string, number[]> = await response.json()
+      library.value = Object.entries(raw).map(([stem, cents]) => ({
+        stem,
+        cents: cents.slice(0, -1),
+        period: cents[cents.length - 1]
+      }))
+    } catch (e) {
+      fetchError.value = e instanceof Error ? e.message : String(e)
+    } finally {
+      isFetching.value = false
+    }
+  }
+
+  function runComputation(allCents: number[]) {
+    if (!library.value.length) return
+    const queryPeriod = allCents[allCents.length - 1]
+    const queryCents = allCents.slice(0, -1).sort((a, b) => a - b)
+    result.value = computeSimilarScales(queryCents, queryPeriod, library.value)
+  }
+
+  return { library, isFetching, fetchError, result, fetchLibrary, runComputation }
+})

--- a/src/stores/similar.ts
+++ b/src/stores/similar.ts
@@ -1,9 +1,7 @@
 import { ref } from 'vue'
 import { defineStore } from 'pinia'
 import { computeSimilarScales, type LibraryScale, type SimilarResult } from '@/similar-scales'
-
-const SCALE_CENTS_URL =
-  'https://cdn.jsdelivr.net/npm/@narenratan/scale-library@1.3.0/scale-cents.json'
+import SCALE_CENTS_URL from '@narenratan/scale-library/scale-cents.json?url'
 
 /**
  * Scale library cache and similar-scales computation store.

--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -56,6 +56,7 @@ const tagline = computed(() => TAGLINES[Math.floor(Math.random() * TAGLINES.leng
         Videco - <i>developer</i> <br />
         Inthar - <i>developer</i> <br />
         Wilckerson Ganda - <i>developer</i> <br />
+        Naren Ratan - <i>developer</i> <br />
         Marc Sabat - <i>developer / notation-hardware advisor</i> <br />
         Tristan Bay - <i>developer / preset advisor</i> <br />
         Arsenii 0.5° - <i>developer / aperiodic consult</i> <br />

--- a/src/views/AnalysisView.vue
+++ b/src/views/AnalysisView.vue
@@ -759,7 +759,7 @@ watch(subtab, async (newValue) => {
                     :href="`https://scalelibrary.org/scales/${entry.stem}/`"
                     target="_blank"
                     rel="noopener"
-                    >{{ stemBasename(entry.stem) }}</a
+                    >{{ stemBasename(entry.stem) }} 🔗</a
                   >
                 </td>
                 <td>{{ entry.notes }}</td>
@@ -788,7 +788,7 @@ watch(subtab, async (newValue) => {
                     :href="`https://scalelibrary.org/scales/${entry.stem}/`"
                     target="_blank"
                     rel="noopener"
-                    >{{ stemBasename(entry.stem) }}</a
+                    >{{ stemBasename(entry.stem) }} 🔗</a
                   >
                 </td>
                 <td>{{ entry.notes }}</td>
@@ -816,7 +816,7 @@ watch(subtab, async (newValue) => {
                     :href="`https://scalelibrary.org/scales/${entry.stem}/`"
                     target="_blank"
                     rel="noopener"
-                    >{{ stemBasename(entry.stem) }}</a
+                    >{{ stemBasename(entry.stem) }} 🔗</a
                   >
                 </td>
                 <td>{{ entry.notes }}</td>

--- a/src/views/AnalysisView.vue
+++ b/src/views/AnalysisView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 /**
- * Analysis workspace view for interval matrices, chord wheels, and harmonic entropy plots.
+ * Analysis workspace view for interval matrices, chord wheels,
+ * harmonic entropy plots, and similar scale tables.
  */
 import { type Interval } from 'sonic-weave/interval'
 import {
@@ -25,6 +26,8 @@ import { Fraction, lcm, mmod } from 'xen-dev-utils/fraction'
 import { useScaleStore } from '@/stores/scale'
 import { OCTAVE, UNISON } from '@/constants'
 import { useHarmonicEntropyStore } from '@/stores/harmonic-entropy'
+import { useSimilarStore, SCALE_LIBRARY_BASE } from '@/stores/similar'
+import { stemBasename } from '@/similar-scales'
 import Values from 'values.js'
 
 const EPSILON = 1e-6
@@ -33,8 +36,9 @@ const audio = useAudioStore()
 const state = useStateStore()
 const scale = useScaleStore()
 const entropy = useHarmonicEntropyStore()
+const similar = useSimilarStore()
 
-const subtab = ref<'matrix' | 'wheels' | 'entropy'>('matrix')
+const subtab = ref<'matrix' | 'wheels' | 'entropy' | 'similar'>('matrix')
 const cellFormat = ref<'best' | 'fraction' | 'cents' | 'et' | 'decimal'>('best')
 const simplifyTolerance = ref(3.5)
 const fractionMaxHeight = ref(26)
@@ -308,9 +312,13 @@ const colors = computed(() =>
   centsValues.value.map((_, i) => scale.colorForIndex(scale.baseMidiNote + entropyMode.value + i))
 )
 
-watch(subtab, (newValue) => {
+watch(subtab, async (newValue) => {
   if (newValue === 'entropy') {
     void entropy.fetchTable()
+  }
+  if (newValue === 'similar') {
+    await similar.fetchLibrary()
+    similar.runComputation(scale.relativeIntervals.map((i) => i.totalCents(true)))
   }
 })
 </script>
@@ -332,6 +340,11 @@ watch(subtab, (newValue) => {
         <li>
           <a href="#" :class="{ active: subtab === 'entropy' }" @click="subtab = 'entropy'"
             >Harmonic entropy</a
+          >
+        </li>
+        <li>
+          <a href="#" :class="{ active: subtab === 'similar' }" @click="subtab = 'similar'"
+            >Similar scales</a
           >
         </li>
       </ul>
@@ -721,6 +734,99 @@ watch(subtab, (newValue) => {
         </table>
       </div>
     </main>
+    <main v-if="subtab === 'similar'" class="similar-scales">
+      <p v-if="similar.isFetching">Fetching scale library data…</p>
+      <p v-else-if="similar.fetchError" class="error">
+        Failed to load scale library: {{ similar.fetchError }}
+      </p>
+      <template v-else-if="similar.result">
+        <section>
+          <h2>Similar scales</h2>
+          <p v-if="!similar.result.similar.length">No similar scales found.</p>
+          <table v-else>
+            <thead>
+              <tr>
+                <th>File</th>
+                <th>Notes</th>
+                <th>Rotation</th>
+                <th>Max diff (¢)</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="entry in similar.result.similar" :key="entry.stem">
+                <td>
+                  <a
+                    :href="`${SCALE_LIBRARY_BASE}/scales/${entry.stem}/`"
+                    target="_blank"
+                    rel="noopener"
+                    >{{ stemBasename(entry.stem) }}</a
+                  >
+                </td>
+                <td>{{ entry.notes }}</td>
+                <td>{{ entry.mode }}</td>
+                <td>{{ entry.maxDiff.toFixed(1) }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+
+        <section>
+          <h2>Parent scales</h2>
+          <p v-if="!similar.result.parents.length">No parent scales found.</p>
+          <table v-else>
+            <thead>
+              <tr>
+                <th>File</th>
+                <th>Notes</th>
+                <th>Max diff (¢)</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="entry in similar.result.parents" :key="entry.stem">
+                <td>
+                  <a
+                    :href="`${SCALE_LIBRARY_BASE}/scales/${entry.stem}/`"
+                    target="_blank"
+                    rel="noopener"
+                    >{{ stemBasename(entry.stem) }}</a
+                  >
+                </td>
+                <td>{{ entry.notes }}</td>
+                <td>{{ entry.maxDiff.toFixed(1) }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+
+        <section>
+          <h2>Child scales</h2>
+          <p v-if="!similar.result.children.length">No child scales found.</p>
+          <table v-else>
+            <thead>
+              <tr>
+                <th>File</th>
+                <th>Notes</th>
+                <th>Max diff (¢)</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="entry in similar.result.children" :key="entry.stem">
+                <td>
+                  <a
+                    :href="`${SCALE_LIBRARY_BASE}/scales/${entry.stem}/`"
+                    target="_blank"
+                    rel="noopener"
+                    >{{ stemBasename(entry.stem) }}</a
+                  >
+                </td>
+                <td>{{ entry.notes }}</td>
+                <td>{{ entry.maxDiff.toFixed(1) }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+      </template>
+    </main>
   </div>
 </template>
 
@@ -833,6 +939,32 @@ main {
 .entropy-intervals table {
   border-collapse: collapse;
   text-align: center;
+}
+
+/* Similar scales */
+.similar-scales {
+  padding: 0.5rem 1rem;
+  overflow-y: auto;
+}
+.similar-scales section {
+  margin-bottom: 1.5rem;
+}
+.similar-scales table {
+  border-collapse: collapse;
+}
+.similar-scales th,
+.similar-scales td {
+  border: 1px solid var(--color-border);
+  padding: 0.2rem 0.6rem;
+}
+.similar-scales th {
+  font-weight: bold;
+}
+.similar-scales a {
+  color: var(--color-accent-text-btn);
+}
+.similar-scales .error {
+  color: var(--color-error);
 }
 
 /* Content layout (medium) */

--- a/src/views/AnalysisView.vue
+++ b/src/views/AnalysisView.vue
@@ -771,8 +771,8 @@ watch(subtab, async (newValue) => {
         </section>
 
         <section>
-          <h2>Parent scales</h2>
-          <p v-if="!similar.result.parents.length">No parent scales found.</p>
+          <h2>Child scales</h2>
+          <p v-if="!similar.result.children.length">No child scales found.</p>
           <table v-else>
             <thead>
               <tr>
@@ -782,7 +782,7 @@ watch(subtab, async (newValue) => {
               </tr>
             </thead>
             <tbody>
-              <tr v-for="entry in similar.result.parents" :key="entry.stem">
+              <tr v-for="entry in similar.result.children" :key="entry.stem">
                 <td>
                   <a
                     :href="`https://scalelibrary.org/scales/${entry.stem}/`"
@@ -799,8 +799,8 @@ watch(subtab, async (newValue) => {
         </section>
 
         <section>
-          <h2>Child scales</h2>
-          <p v-if="!similar.result.children.length">No child scales found.</p>
+          <h2>Parent scales</h2>
+          <p v-if="!similar.result.parents.length">No parent scales found.</p>
           <table v-else>
             <thead>
               <tr>
@@ -810,7 +810,7 @@ watch(subtab, async (newValue) => {
               </tr>
             </thead>
             <tbody>
-              <tr v-for="entry in similar.result.children" :key="entry.stem">
+              <tr v-for="entry in similar.result.parents" :key="entry.stem">
                 <td>
                   <a
                     :href="`https://scalelibrary.org/scales/${entry.stem}/`"

--- a/src/views/AnalysisView.vue
+++ b/src/views/AnalysisView.vue
@@ -26,7 +26,7 @@ import { Fraction, lcm, mmod } from 'xen-dev-utils/fraction'
 import { useScaleStore } from '@/stores/scale'
 import { OCTAVE, UNISON } from '@/constants'
 import { useHarmonicEntropyStore } from '@/stores/harmonic-entropy'
-import { useSimilarStore, SCALE_LIBRARY_BASE } from '@/stores/similar'
+import { useSimilarStore } from '@/stores/similar'
 import { stemBasename } from '@/similar-scales'
 import Values from 'values.js'
 
@@ -756,7 +756,7 @@ watch(subtab, async (newValue) => {
               <tr v-for="entry in similar.result.similar" :key="entry.stem">
                 <td>
                   <a
-                    :href="`${SCALE_LIBRARY_BASE}/scales/${entry.stem}/`"
+                    :href="`https://scalelibrary.org/scales/${entry.stem}/`"
                     target="_blank"
                     rel="noopener"
                     >{{ stemBasename(entry.stem) }}</a
@@ -785,7 +785,7 @@ watch(subtab, async (newValue) => {
               <tr v-for="entry in similar.result.parents" :key="entry.stem">
                 <td>
                   <a
-                    :href="`${SCALE_LIBRARY_BASE}/scales/${entry.stem}/`"
+                    :href="`https://scalelibrary.org/scales/${entry.stem}/`"
                     target="_blank"
                     rel="noopener"
                     >{{ stemBasename(entry.stem) }}</a
@@ -813,7 +813,7 @@ watch(subtab, async (newValue) => {
               <tr v-for="entry in similar.result.children" :key="entry.stem">
                 <td>
                   <a
-                    :href="`${SCALE_LIBRARY_BASE}/scales/${entry.stem}/`"
+                    :href="`https://scalelibrary.org/scales/${entry.stem}/`"
                     target="_blank"
                     rel="noopener"
                     >{{ stemBasename(entry.stem) }}</a

--- a/src/views/AnalysisView.vue
+++ b/src/views/AnalysisView.vue
@@ -759,7 +759,8 @@ watch(subtab, async (newValue) => {
                     :href="`https://scalelibrary.org/scales/${entry.stem}/`"
                     target="_blank"
                     rel="noopener"
-                    >{{ stemBasename(entry.stem) }} 🔗</a
+                    class="external-link"
+                    >{{ stemBasename(entry.stem) }}</a
                   >
                 </td>
                 <td>{{ entry.notes }}</td>
@@ -788,7 +789,8 @@ watch(subtab, async (newValue) => {
                     :href="`https://scalelibrary.org/scales/${entry.stem}/`"
                     target="_blank"
                     rel="noopener"
-                    >{{ stemBasename(entry.stem) }} 🔗</a
+                    class="external-link"
+                    >{{ stemBasename(entry.stem) }}</a
                   >
                 </td>
                 <td>{{ entry.notes }}</td>
@@ -816,7 +818,8 @@ watch(subtab, async (newValue) => {
                     :href="`https://scalelibrary.org/scales/${entry.stem}/`"
                     target="_blank"
                     rel="noopener"
-                    >{{ stemBasename(entry.stem) }} 🔗</a
+                    class="external-link"
+                    >{{ stemBasename(entry.stem) }}</a
                   >
                 </td>
                 <td>{{ entry.notes }}</td>
@@ -965,6 +968,12 @@ main {
 }
 .similar-scales .error {
   color: var(--color-error);
+}
+
+a.external-link::after {
+  content: '🔗';
+  display: inline-block;
+  margin-left: 0.25rem;
 }
 
 /* Content layout (medium) */


### PR DESCRIPTION
I've been working on [scalelibrary.org](https://scalelibrary.org), a library of microtonal scales with sources attributed, and I've found the tables of similar, parent, and child scales super interesting (for example on [this scale page](https://scalelibrary.org/scales/damusc/Georgia_GVM206-M/)). I thought it might be interesting to show these tables in Scale Workshop - I got something working so I thought I'd make a PR to at least have something concrete to talk about. I've attached a screenshot (there's a Child scales table off-screen).

<img width="746" height="899" alt="screenshot" src="https://github.com/user-attachments/assets/7de16741-0488-4c9e-b181-3b41be324f2b" />
