### PR TITLE
Check for win32 when setting unit test newlines

### DIFF
--- a/src/exporters/__tests__/ableton.spec.ts
+++ b/src/exporters/__tests__/ableton.spec.ts
@@ -4,7 +4,7 @@ import AbletonAsclExporter from '../ableton'
 import { getTestData } from './test-data'
 import { NEWLINE_TEST, UNIX_NEWLINE, WINDOWS_NEWLINE } from '../../constants'
 
-const NEWLINE = process.platform === 'linux' ? UNIX_NEWLINE : WINDOWS_NEWLINE
+const NEWLINE = process.platform === 'win32' ? WINDOWS_NEWLINE : UNIX_NEWLINE
 
 describe('Scala exporters', () => {
   it('can handle all line types', () => {

--- a/src/exporters/__tests__/scala.spec.ts
+++ b/src/exporters/__tests__/scala.spec.ts
@@ -4,7 +4,7 @@ import { ScalaSclExporter, ScalaKbmExporter } from '../scala'
 import { getTestData } from './test-data'
 import { UNIX_NEWLINE, WINDOWS_NEWLINE } from '../../constants'
 
-const NEWLINE = process.platform === 'linux' ? UNIX_NEWLINE : WINDOWS_NEWLINE
+const NEWLINE = process.platform === 'win32' ? WINDOWS_NEWLINE : UNIX_NEWLINE
 
 describe('Scala exporters', () => {
   it('can handle all line types', () => {

--- a/src/exporters/__tests__/test-data.ts
+++ b/src/exporters/__tests__/test-data.ts
@@ -85,7 +85,7 @@ export function getTestData(appTitle: string, raw = false) {
   const scale = new Scale(ratios, 440, 69, 'Test Scale')
   const params: ExporterParams = {
     filename: 'test',
-    newline: process.platform === 'linux' ? UNIX_NEWLINE : WINDOWS_NEWLINE,
+    newline: process.platform === 'win32' ? WINDOWS_NEWLINE : UNIX_NEWLINE,
     scaleUrl: 'https://scaleworkshop.plainsound.org/',
     relativeIntervals,
     scale,


### PR DESCRIPTION
I was getting some unit test failures on Mac from Windows vs Unix line endings. With these changes all the tests pass on Mac, and behaviour on Linux and Windows should be unchanged.